### PR TITLE
Allow including optionals in return of matchedData

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ These methods are all available via `require('express-validator/filter')`.
 ### `matchedData(req[, options])`
 - `req`: the express request object.
 - `options` *(optional)*: an object which accepts the following options:
+  - `includeOptionals`: if set to `true`, the returned value includes optional data. Defaults to `false`.
   - `onlyValidData`: if set to `false`, the returned value includes data from fields
     that didn't pass their validations. Defaults to `true`.
   - `locations`: an array of locations to extract the data from. The acceptable values include

--- a/filter/matched-data.d.ts
+++ b/filter/matched-data.d.ts
@@ -4,6 +4,7 @@ import { Location } from '../check/location';
 export function matchedData(req: express.Request, options?: Partial<MatchedDataOptions>): Record<string, any>;
 
 export interface MatchedDataOptions {
+  filterOptionals: boolean;
   onlyValidData: boolean;
   locations: Location[];
 }

--- a/filter/matched-data.js
+++ b/filter/matched-data.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const selectFields = require('../utils/select-fields');
 
 module.exports = (req, options = {}) => {
-  const fieldExtractor = createFieldExtractor(req);
+  const fieldExtractor = createFieldExtractor(req, options);
   const validityFilter = createValidityFilter(req, options);
   const locationsFilter = createLocationFilter(options);
 
@@ -15,8 +15,9 @@ module.exports = (req, options = {}) => {
     .valueOf();
 };
 
-function createFieldExtractor(req) {
+function createFieldExtractor(req, { includeOptionals }) {
   return context => [].concat(selectFields(req, context, {
+    filterOptionals: includeOptionals !== true,
     // By the time we get here, all sanitizers did run, so we don't want double sanitization.
     sanitize: false
   })).map(instance => ({

--- a/filter/matched-data.spec.js
+++ b/filter/matched-data.spec.js
@@ -3,13 +3,13 @@ const { check, oneOf } = require('../check');
 const { matchedData } = require('./');
 
 describe('filter: matchedData', () => {
-  it('includes only valid data in the request', () => {
+  it('includes only valid, non-optional data in the request', () => {
     const req = {
       query: { foo: '123', bar: 'abc', baz: 'def' },
       body: { foo: 'abc' }
     };
 
-    return check(['foo', 'bar']).isInt()(req, {}, () => {}).then(() => {
+    return check(['foo', 'bar', 'qux']).optional().isInt()(req, {}, () => {}).then(() => {
       const data = matchedData(req);
       expect(data).to.eql({ foo: '123' });
     });
@@ -89,6 +89,19 @@ describe('filter: matchedData', () => {
       ]).then(() => {
         const data = matchedData(req);
         expect(data).to.eql({ bar: '123', baz: 'baz' });
+      });
+    });
+  });
+
+  describe('when option includeOptionals is set to true', () => {
+    it('returns object with optional data validated in the request', () => {
+      const req = {
+        body: { foo: '123' }
+      };
+
+      return check(['foo', 'bar']).optional().isInt()(req, {}, () => {}).then(() => {
+        const data = matchedData(req, { includeOptionals: true });
+        expect(data).to.eql({ foo: '123', bar: undefined });
       });
     });
   });

--- a/filter/matched-data.spec.ts
+++ b/filter/matched-data.spec.ts
@@ -4,6 +4,7 @@ let dataRecord: Record<string, any> = matchedData({} as any);
 dataRecord = matchedData({} as any, {});
 dataRecord = matchedData({} as any, {
   locations: ['body', 'cookies'],
+  filterOptionals: true,
   onlyValidData: true
 });
 

--- a/utils/select-fields.js
+++ b/utils/select-fields.js
@@ -3,7 +3,9 @@ const formatParamOutput = require('./format-param-output');
 
 module.exports = (req, context, options = {}) => {
   let allFields = [];
-  const optionalityFilter = createOptionalityFilter(context);
+  const optionalityFilter = options.filterOptionals == null || options.filterOptionals
+    ? createOptionalityFilter(context)
+    : Boolean;
   const sanitizerMapper = createSanitizerMapper(req, context, options);
 
   context.fields.map(field => field == null ? '' : field).forEach(field => {

--- a/utils/select-fields.spec.js
+++ b/utils/select-fields.spec.js
@@ -297,6 +297,20 @@ describe('utils: selectFields', () => {
 
       expect(instances).to.have.length(0);
     });
+
+    it('keeps optional data if option filterOptionals is false', () => {
+      const instances = selectFields({
+        params: { bar: null }
+      }, {
+        optional: { nullable: true },
+        locations: ['params'],
+        fields: ['foo', 'bar']
+      }, {
+        filterOptionals: false
+      });
+
+      expect(instances).to.have.length(2);
+    });
   });
 
   describe('when there are multiple locations', () => {


### PR DESCRIPTION
Adds an option `includeOptionals` for this, otherwise it could be a breaking change.

Closes #568 
