### PR TITLE
Small correction to the sanitizer docs example

### DIFF
--- a/docs/feature-custom-validators-sanitizers.md
+++ b/docs/feature-custom-validators-sanitizers.md
@@ -56,7 +56,7 @@ moment.
 const { sanitizeParam } = require('express-validator/filter');
 
 app.post('/object/:id', sanitizeParam('id').customSanitizer(value => {
-  return ObjectId(id);
+  return ObjectId(value);
 }), (req, res) => {
   // Handle the request
 });


### PR DESCRIPTION
`id` is the name of the URL param being sanitized... but the variable in the function is named `value`.