### PR TITLE
Update "Do not use a common word" example

### DIFF
--- a/docs/feature-error-messages.md
+++ b/docs/feature-error-messages.md
@@ -68,7 +68,7 @@ const { check } = require('express-validator/check');
 app.post('/user', [
   // ...some other validations...
   check('password', 'The password must be 5+ chars long and contain a number')
-    .not().in(['123', 'password', 'god']).withMessage('Do not use a common word as the password')
+    .not().isIn(['123', 'password', 'god']).withMessage('Do not use a common word as the password')
     .isLength({ min: 5 })
     .matches(/\d/)
 ], (req, res) => {


### PR DESCRIPTION
`check().not().in()` results in: 
```
TypeError: check(...).not(...).in is not a function
```

Updated to be `check().not().isIn()` instead (see: https://express-validator.github.io/docs/validation-chain-api.html#not)