### PR TITLE
Add `defined` option for optional

### DIFF
--- a/docs/api-validation-chain.md
+++ b/docs/api-validation-chain.md
@@ -163,6 +163,7 @@ By default, fields with `undefined` values will be ignored from the validation.
 You can customize this behavior by passing an object with the following options:
 - `nullable`: if `true`, fields with `null` values will be considered optional
 - `checkFalsy`: if `true`, fields with falsy values (eg `""`, `0`, `false`, `null`) will also be considered optional
+- `defined`: if `true`, field must be defined (cannot be `undefined`). Should be used in combination of `nullable` or `checkFalsy`
 
 ### `.run(req)`
 > *Returns:* a promise that resolves when the validation chain ran.

--- a/src/chain/context-handler-impl.spec.ts
+++ b/src/chain/context-handler-impl.spec.ts
@@ -43,17 +43,19 @@ describe('#if()', () => {
 });
 
 describe('#optional()', () => {
-  it('sets optional flag to { checkFalsy: false, nullable: false } if arg is true', () => {
+  it('sets optional flag to { checkFalsy: false, nullable: false, defined: false } if arg is true', () => {
     contextHandler.optional();
     expect(builder.setOptional).toHaveBeenNthCalledWith(1, {
       checkFalsy: false,
       nullable: false,
+      defined: false,
     });
 
     contextHandler.optional(true);
     expect(builder.setOptional).toHaveBeenNthCalledWith(2, {
       checkFalsy: false,
       nullable: false,
+      defined: false,
     });
   });
 
@@ -62,15 +64,31 @@ describe('#optional()', () => {
     expect(builder.setOptional).toHaveBeenNthCalledWith(1, {
       checkFalsy: false,
       nullable: true,
+      defined: false,
     });
 
     contextHandler.optional({ checkFalsy: true });
     expect(builder.setOptional).toHaveBeenNthCalledWith(2, {
       checkFalsy: true,
       nullable: false,
+      defined: false,
+    });
+
+    contextHandler.optional({ defined: true });
+    expect(builder.setOptional).toHaveBeenNthCalledWith(3, {
+      checkFalsy: false,
+      nullable: false,
+      defined: true,
+    });
+
+    contextHandler.optional({ defined: true, nullable: true });
+    expect(builder.setOptional).toHaveBeenNthCalledWith(4, {
+      checkFalsy: false,
+      nullable: true,
+      defined: true,
     });
 
     contextHandler.optional(false);
-    expect(builder.setOptional).toHaveBeenNthCalledWith(3, false);
+    expect(builder.setOptional).toHaveBeenNthCalledWith(5, false);
   });
 });

--- a/src/chain/context-handler-impl.ts
+++ b/src/chain/context-handler-impl.ts
@@ -27,11 +27,14 @@ export class ContextHandlerImpl<Chain> implements ContextHandler<Chain> {
 
   optional(options: Optional | true = true) {
     if (typeof options === 'boolean') {
-      this.builder.setOptional(options ? { checkFalsy: false, nullable: false } : false);
+      this.builder.setOptional(
+        options ? { checkFalsy: false, nullable: false, defined: false } : false,
+      );
     } else {
       this.builder.setOptional({
         checkFalsy: !!options.checkFalsy,
         nullable: !!options.nullable,
+        defined: !!options.defined,
       });
     }
 

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -36,7 +36,7 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     return this.addItem(new CustomValidation(validator, this.negateNext));
   }
 
-  exists(options: { checkFalsy?: boolean; checkNull?: boolean } = {}) {
+  exists(options: { checkFalsy?: boolean; checkNull?: boolean; defined?: boolean } = {}) {
     let validator: CustomValidator;
     if (options.checkFalsy) {
       validator = value => !!value;

--- a/src/chain/validators.ts
+++ b/src/chain/validators.ts
@@ -9,7 +9,7 @@ export interface Validators<Return> {
 
   // custom validators
   custom(validator: CustomValidator): Return;
-  exists(options?: { checkFalsy?: boolean; checkNull?: boolean }): Return;
+  exists(options?: { checkFalsy?: boolean; checkNull?: boolean; defined?: boolean }): Return;
   isArray(options?: { min?: number; max?: number }): Return;
   isString(): Return;
   notEmpty(options?: Options.IsEmptyOptions): Return;

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -137,6 +137,25 @@ describe('#getData()', () => {
     expect(context.getData({ requiredOnly: true })).toEqual([]);
   });
 
+  it('filters out only nulls when context optional with nullable = true and defined = true', () => {
+    data[0].value = null;
+    data[1].value = undefined;
+    data[2] = {
+      location: 'body',
+      originalPath: 'bar',
+      path: 'bar',
+      originalValue: 'baz',
+      value: 'baz',
+    };
+
+    context = new ContextBuilder()
+      .setOptional({ checkFalsy: false, nullable: true, defined: true })
+      .build();
+    context.addFieldInstances(data);
+
+    expect(context.getData({ requiredOnly: true })).toEqual([data[1], data[2]]);
+  });
+
   describe('when same path occurs multiple times', () => {
     it('keeps only fields with value', () => {
       data = [

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,7 @@ function getDataMapKey(path: string, location: Location) {
   return `${location}:${path}`;
 }
 
-export type Optional = { nullable: boolean; checkFalsy: boolean } | false;
+export type Optional = { nullable: boolean; checkFalsy: boolean; defined?: boolean } | false;
 
 export class Context {
   private readonly _errors: ValidationError[] = [];
@@ -31,8 +31,12 @@ export class Context {
     const checks =
       options.requiredOnly && optional
         ? [
-            (value: any) => value !== undefined,
-            (value: any) => (optional.nullable ? value != null : true),
+            (value: any) =>
+              optional.nullable
+                ? optional.defined
+                  ? value !== null
+                  : value != null
+                : value !== undefined,
             (value: any) => (optional.checkFalsy ? value : true),
           ]
         : [];

--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -155,6 +155,7 @@ describe('on each field', () => {
           options: {
             checkFalsy: true,
             nullable: true,
+            defined: false,
           },
         },
       },
@@ -163,11 +164,13 @@ describe('on each field', () => {
     expect(chainToContext(schema[0]).optional).toEqual({
       checkFalsy: false,
       nullable: false,
+      defined: false,
     });
 
     expect(chainToContext(schema[1]).optional).toEqual({
       checkFalsy: true,
       nullable: true,
+      defined: false,
     });
   });
 


### PR DESCRIPTION
Adds new option for `optional`: `defined`, which requires one to define given property. Should be used in combination of `checkFalsy` or `nullable`.
I made this, because REST principles declare that one should always send whole object on update and create, and explicity set optional values `null`. Previously this could be achieved only with oneOf: null or real validator.
Does not change default functionality.