### PR TITLE
Tests for customSanitizers with strings and other types

### DIFF
--- a/check/one-of.spec.js
+++ b/check/one-of.spec.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { check, oneOf } = require('./');
+const { check, cookie, oneOf } = require('./');
 
 describe('check: checkOneOf middleware', () => {
   it('returns errors from all chains', () => {
@@ -61,7 +61,7 @@ describe('check: checkOneOf middleware', () => {
 
     return oneOf([
       check('foo').trim(),
-      [check('foo').customSanitizer(value => value.toUpperCase())]
+      [cookie('foo').customSanitizer(value => value.toUpperCase())]
     ])(req, {}, () => {}).then(() => {
       expect(req.cookies.foo).to.equal('BAR');
     });

--- a/filter/sanitize.spec.js
+++ b/filter/sanitize.spec.js
@@ -56,5 +56,71 @@ describe('filter: sanitize', () => {
 
       expect(req.body.foo).to.equal(42);
     });
+
+    it('runs a custom inline sanitizer on string types', () => {
+      const req = {
+        body: { foo: '42' }
+      };
+
+      const chain = sanitize('foo', ['body']).customSanitizer(() => true);
+      chain(req, {}, () => {});
+
+      expect(req.body.foo).to.equal(true);
+    });
+
+    it('runs a custom inline sanitizer on undefined types', () => {
+      const req = {
+        body: { foo: undefined }
+      };
+
+      const chain = sanitize('foo', ['body']).customSanitizer(() => true);
+      chain(req, {}, () => {});
+
+      expect(req.body.foo).to.equal(true);
+    });
+
+    it('runs a custom inline sanitizer on number types', () => {
+      const req = {
+        body: { foo: 42 }
+      };
+
+      const chain = sanitize('foo', ['body']).customSanitizer(() => true);
+      chain(req, {}, () => {});
+
+      expect(req.body.foo).to.equal(true);
+    });
+
+    it('runs a custom inline sanitizer on object types', () => {
+      const req = {
+        body: { foo: {} }
+      };
+
+      const chain = sanitize('foo', ['body']).customSanitizer(() => true);
+      chain(req, {}, () => {});
+
+      expect(req.body.foo).to.equal(true);
+    });
+
+    it('runs a custom inline sanitizer on array types', () => {
+      const req = {
+        body: { foo: [] }
+      };
+
+      const chain = sanitize('foo', ['body']).customSanitizer(() => true);
+      chain(req, {}, () => {});
+
+      expect(req.body.foo).to.equal(true);
+    });
+
+    it('runs a custom inline sanitizer on boolean types', () => {
+      const req = {
+        body: { foo: false }
+      };
+
+      const chain = sanitize('foo', ['body']).customSanitizer(() => true);
+      chain(req, {}, () => {});
+
+      expect(req.body.foo).to.equal(true);
+    });
   });
 });

--- a/utils/select-fields.js
+++ b/utils/select-fields.js
@@ -70,7 +70,7 @@ function expand(object, path, paths) {
 
 function createSanitizerMapper(req, { sanitizers = [] }, { sanitize = true }) {
   return !sanitize ? field => field : field => sanitizers.reduce((prev, sanitizer) => {
-    const value = typeof prev.value === 'string' ?
+    const value = sanitizer.custom || typeof prev.value === 'string' ?
       callSanitizer(sanitizer, prev) :
       prev.value;
 


### PR DESCRIPTION
customSanitizers can (with another PR) run on other types of values including undefined, so the check must be more specific or the customSanitizer must check for undefined values.

This fixes the tests for #632 , but can be merged independently if acceptable and passes CI.