### PR TITLE
.withData() support

### DIFF
--- a/check/check.js
+++ b/check/check.js
@@ -90,11 +90,11 @@ module.exports = (fields, locations, message) => {
     return middleware;
   };
 
-  middleware.withData = (data, destructure = true) => {
+  middleware.withData = (data, spread = true) => {
     const lastValidator = validators[validators.length - 1];
     if (lastValidator) {
       lastValidator.extraData =
-        destructure
+        spread
           ? data
           : { data };
     }

--- a/check/check.js
+++ b/check/check.js
@@ -90,6 +90,17 @@ module.exports = (fields, locations, message) => {
     return middleware;
   };
 
+  middleware.withData = (data, destructure = true) => {
+    const lastValidator = validators[validators.length - 1];
+    if (lastValidator) {
+      lastValidator.extraData =
+        destructure
+          ? data
+          : { data };
+    }
+    return middleware;
+  }
+
   middleware.not = () => {
     middleware._context.negateNext = true;
     return middleware;
@@ -104,7 +115,8 @@ module.exports = (fields, locations, message) => {
     fields,
     locations,
     sanitizers,
-    validators
+    validators,
+    extraData: {}
   };
 
   return middleware;

--- a/check/check.spec.js
+++ b/check/check.spec.js
@@ -53,7 +53,7 @@ describe('check: low-level middleware', () => {
     };
     const chain = check('foo', ['body']).trim();
 
-    return chain(req, {}, () => {}).then(() => {
+    return chain(req, {}, () => { }).then(() => {
       expect(req.body.foo).to.equal('bar');
     });
   });
@@ -107,6 +107,39 @@ describe('check: low-level middleware', () => {
     it('does not throw when there are no validators', () => {
       const chain = check('foo', []);
       expect(chain.withMessage).to.not.throw(Error);
+    });
+  });
+
+  describe('.withData()', () => {
+    it('sets data for last validator', () => {
+      const chain = check('foo', [])
+        .isUppercase()
+        .isEmail().withData({ code: '1' }).withMessage('hi!');
+      const { validators } = chain._context;
+      expect(validators).to.not.have.nested.property('[0].extraData.code');
+      expect(validators).to.have.nested.property('[1].extraData.code', '1');
+    });
+
+    it('sets data for multiple validators', () => {
+      const chain = check('foo', [])
+        .isUppercase().withData({ code: '1' })
+        .isEmail().withData({ code: '2' });
+
+      const { validators } = chain._context;
+      expect(validators).to.have.nested.property('[0].extraData.code', '1');
+      expect(validators).to.have.nested.property('[1].extraData.code', '2');
+    });
+
+    it('nests object when requested to not spread', () => {
+      const chain = check('foo', [])
+        .isUppercase().withData({ code: '1' }, false)
+      const { validators } = chain._context;
+      expect(validators).to.have.nested.property('[0].extraData.data.code', '1');
+    });
+
+    it('does not throw error when there are no validators', () => {
+      const chain = check('foo', []);
+      expect(chain.withData).to.not.throw(Error);
     });
   });
 
@@ -188,7 +221,7 @@ describe('check: low-level middleware', () => {
         body: { foo: 'foo@example.com', bar: 'not_email' }
       };
 
-      return check(['foo', 'bar'], ['body']).isEmail()(req, {}, () => {}).then(() => {
+      return check(['foo', 'bar'], ['body']).isEmail()(req, {}, () => { }).then(() => {
         expect(req)
           .to.have.property('_validationErrors')
           .that.is.an('array')
@@ -202,8 +235,8 @@ describe('check: low-level middleware', () => {
       };
 
       return Promise.all([
-        check('foo', ['query']).isAlpha()(req, {}, () => {}),
-        check('bar', ['query']).isInt()(req, {}, () => {})
+        check('foo', ['query']).isAlpha()(req, {}, () => { }),
+        check('bar', ['query']).isInt()(req, {}, () => { })
       ]).then(() => {
         expect(req._validationErrors).to.have.length(2);
       });

--- a/check/runner.js
+++ b/check/runner.js
@@ -16,7 +16,7 @@ module.exports = (req, context) => {
         }
       });
     }).catch(err => {
-      validationErrors.push({
+      let validationError = {
         location,
         param: path,
         value: field.originalValue,
@@ -27,7 +27,9 @@ module.exports = (req, context) => {
           context.message,
           'Invalid value'
         ], field, req)
-      });
+      };
+      validationError = Object.assign(validationError, validatorCfg.extraData);
+      validationErrors.push(validationError);
     }), Promise.resolve());
   });
 

--- a/check/schema.js
+++ b/check/schema.js
@@ -3,46 +3,81 @@ const check = require('./check');
 const validLocations = ['body', 'cookies', 'headers', 'params', 'query'];
 const notValidators = ['errorMessage', 'in'];
 
-module.exports = (
-  schema,
-  defaultLocations = validLocations,
-  chainCreator = check
-) => Object.keys(schema).map(field => {
-  const config = schema[field];
-  const chain = chainCreator(
-    field,
-    ensureLocations(config, defaultLocations),
+module.exports = function (schema, defaultLocations = validLocations, chainCreator = check) {
+  return new Schema(schema, defaultLocations, chainCreator).toChains();
+}
+
+
+function Schema(schema, defaultLocations, chainCreator) {
+  this._schema = schema;
+  this._defaultLocations = defaultLocations;
+  this._chainCreator = chainCreator;
+}
+
+Schema.prototype.toChains = function () {
+
+  return Object.keys(this._schema).map(
+    (field) => {
+      config = this._schema[field];
+      return new SchemaItem(
+        field, config, this._defaultLocations, this._chainCreator
+      ).toChain();
+    }
+  );
+}
+
+
+function SchemaItem(field, config, defaultLocations, chainCreator) {
+  this._field = field;
+  this._config = config;
+  this._defaultLocations = defaultLocations;
+  this._chainCreator = chainCreator;
+}
+
+SchemaItem.prototype.toChain = function () {
+  const config = this._config;
+  const chain = this._chainCreator(
+    this._field,
+    this._getLocations(),
     config.errorMessage
   );
 
-  Object.keys(config)
-    .filter(method => config[method] && !notValidators.includes(method))
-    .forEach(method => {
-      if (typeof chain[method] !== 'function') {
-        console.warn(`express-validator: a validator with name ${method} does not exist`);
-        return;
-      }
+  for (let methodTitle of Object.keys(config)) {
+    const methodConfig = config[methodTitle];
+    if (!methodConfig || notValidators.includes(methodTitle)) {
+      continue;
+    }
+    if (typeof chain[methodTitle] !== 'function') {
+      console.warn(`express-validator: a validator with name ${methodTitle} does not exist`);
+      break;
+    }
+    const options = obtainOptionsFromMethodConfig(methodConfig);
 
-      const methodCfg = config[method];
+    const methodIsValidator = isValidator(methodTitle) || methodTitle === 'custom' || methodTitle === 'exists';
 
-      let options = methodCfg.options || [];
-      if (options != null && !Array.isArray(options)) {
-        options = [options];
-      }
-
-      const methodIsValidator = isValidator(method) || method === 'custom' || method === 'exists';
-
-      methodIsValidator && methodCfg.negated && chain.not();
-      chain[method](...options);
-      methodIsValidator && chain.withMessage(methodCfg.errorMessage);
-    });
-
+    methodIsValidator && methodConfig.negated && chain.not();
+    chain[methodTitle](...options);
+    methodIsValidator && chain.withMessage(methodConfig.errorMessage);
+  }
   return chain;
-});
+}
 
-function ensureLocations(config, defaults) {
-  const locations = (Array.isArray(config.in) ? config.in : [config.in]).filter(Boolean);
-  const actualLocations = locations.length ? locations : defaults;
+SchemaItem.prototype._getLocations = function () {
+  const config = this._config;
+  let locations = (Array.isArray(config.in) ? config.in : [config.in]).filter(Boolean);
+  if (!locations.length) {
+    locations = this._defaultLocations;
+  }
 
-  return actualLocations.filter(location => validLocations.includes(location));
+  return locations.filter(location => validLocations.includes(location));
+}
+
+
+
+function obtainOptionsFromMethodConfig(methodConfig) {
+  let options = methodConfig.options || [];
+  if (options != null && !Array.isArray(options)) {
+    options = [options];
+  }
+  return options;
 }

--- a/docs/api-validation-chain.md
+++ b/docs/api-validation-chain.md
@@ -86,3 +86,10 @@ Sets the error message for the previous validator.
 This will have precedence over errors thrown by a custom validator.
 
 To build dynamic messages, see also [Dynamic Messages](feature-dynamic-messages.md).
+
+## `.withData(data[, spread])`
+- `data`: the data to send if validation fails
+- `spread`: whether or not the object provided should be spread. If not, `data` will instead be placed in a property `data`. Defaults to true.
+> *Returns:* the current validation chain instance
+
+Sets extra data for the previous validator.


### PR DESCRIPTION
Allows a user to incorporate extra data with an error.

```javascript
        check("userId")
            .isInt().withMessage("userId could not be parsed to an integer").withData({ errorCode: 1 })
            .isLength(10).withMessage("userId was not length 10").withData({ errorCode: 2 })
```
This could even be used to send different http status codes depending on the errors in the future. The main purpose of this at the moment, though, would be to allow users of an API to programmatically discern between different errors as opposed to manually reading the error message or using a regular expression.