### PR TITLE
Fix syntax error

### DIFF
--- a/check/check.d.ts
+++ b/check/check.d.ts
@@ -45,7 +45,7 @@ export interface Validator {
   isISO8601(): this;
   isISRC(): this;
   isISBN(version?: number): this;
-  isISSN(options?: ValidatorOptions.IsISSNOptions): this
+  isISSN(options?: ValidatorOptions.IsISSNOptions): this;
   isJSON(): this;
   isLatLong(): this;
   isLength(options: ValidatorOptions.MinMaxOptions): this;


### PR DESCRIPTION
Typescript compiler was failing with:

` node_modules/express-validator/check/check.d.ts:69:58 - error TS1005: ';' expected.`

This adds the missing semicolon.