### PR TITLE
Changed the version of lodash to 4.17.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6541,9 +6541,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">= 6.0.0"
   },
   "dependencies": {
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "validator": "^10.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As mentioned in [this](https://github.com/express-validator/express-validator/issues/674) issue, lodash dependency is upgraded to the latest version