### PR TITLE
context-runners: sanitize non-string fields

### DIFF
--- a/src/context-runners/sanitize.spec.ts
+++ b/src/context-runners/sanitize.spec.ts
@@ -1,6 +1,7 @@
 import { Sanitize } from './sanitize';
 import { Request } from '../base';
 import { Context } from '../context';
+import { FieldInstance } from './context-runner';
 
 let runner: Sanitize;
 let req: Request;
@@ -52,17 +53,105 @@ it('maps instances using standard sanitizers in the context', async () => {
       location: 'query',
       path: 'search',
       originalPath: 'search',
-      value: true,
-      originalValue: true,
+      value: 'result',
+      originalValue: 'result',
     },
   ]);
 
   expect(instances).toHaveLength(1);
   expect(instances[0]).toMatchObject({
-    value: 'wow, so much true!!',
+    value: 'wow, so much result!!',
+  });
+  expect(sanitizer1).toHaveBeenCalledWith('result', '!!');
+  expect(sanitizer2).toHaveBeenCalledWith('result!!', 'wow, so much ');
+});
+
+describe('standard sanitizer string conversion', () => {
+  let context: Context;
+  let sanitizer: jest.Mock;
+  let fieldInstances: FieldInstance[];
+
+  beforeEach(() => {
+    sanitizer = jest.fn(() => true);
+    fieldInstances = [
+      {
+        location: 'query',
+        path: 'search',
+        originalPath: 'search',
+        value: '',
+        originalValue: '',
+      },
+      {
+        location: 'query',
+        path: 'type',
+        originalPath: 'type',
+        value: '',
+        originalValue: '',
+      },
+    ];
+
+    context = new Context([], []);
+    context.addSanitization(sanitizer, { custom: false });
   });
 
-  // #580, #630, #632, #641 - Sanitization of non-string params
-  expect(sanitizer1).toHaveBeenCalledWith('true', '!!');
-  expect(sanitizer2).toHaveBeenCalledWith('true!!', 'wow, so much ');
+  it('works from boolean', async () => {
+    fieldInstances[0].value = true;
+    fieldInstances[1].value = false;
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenCalledWith('true');
+    expect(sanitizer).toHaveBeenCalledWith('false');
+  });
+
+  it('works from number', async () => {
+    fieldInstances[0].value = 10;
+    fieldInstances[1].value = 1.5;
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenCalledWith('10');
+    expect(sanitizer).toHaveBeenCalledWith('1.5');
+  });
+
+  it('works from null, undefined and NaN', async () => {
+    fieldInstances[0].value = null;
+    fieldInstances[1].value = undefined;
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenNthCalledWith(1, '');
+    expect(sanitizer).toHaveBeenNthCalledWith(2, '');
+  });
+
+  it('works from NaN', async () => {
+    fieldInstances[0].value = NaN;
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenNthCalledWith(1, '');
+  });
+
+  it('works from Date', async () => {
+    // new Date(Date.UTC()) makes sure we'll not have to deal with timezones
+    fieldInstances[0].value = new Date(Date.UTC(2019, 4, 1, 10, 30, 50, 0));
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenCalledWith('2019-05-01T10:30:50.000Z');
+  });
+
+  it('works from array', async () => {
+    fieldInstances[0].value = ['foo'];
+    fieldInstances[1].value = ['foo', 'bar'];
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenNthCalledWith(1, 'foo');
+    // TODO Should 2+ arrays be narrowed down to the first item of the array?
+    expect(sanitizer).toHaveBeenNthCalledWith(2, 'foo');
+  });
+
+  it('works from object with toString', async () => {
+    fieldInstances[0].value = {
+      toString: () => 'bla',
+    };
+    await runner.run(req, context, fieldInstances);
+
+    expect(sanitizer).toHaveBeenCalledWith('bla');
+  });
 });

--- a/src/context-runners/sanitize.ts
+++ b/src/context-runners/sanitize.ts
@@ -1,18 +1,14 @@
 import { Context } from '../context';
+import { toString } from '../utils';
 import { ContextRunner, FieldInstance } from './context-runner';
 
 export class Sanitize implements ContextRunner {
   async run(req: any, context: Context, instances: FieldInstance[]) {
     return instances.map(instance => {
       const value = context.sanitizations.reduce((prevValue, sanitization) => {
-        // FIXME https://github.com/express-validator/express-validator/issues/580
-        if (typeof prevValue !== 'string') {
-          return prevValue;
-        }
-
         // TypeScript can't do type inference without `if (custom === false)`
         if (sanitization.custom === false) {
-          return sanitization.sanitizer(prevValue, ...sanitization.options);
+          return sanitization.sanitizer(toString(prevValue), ...sanitization.options);
         }
 
         return sanitization.sanitizer(prevValue, {

--- a/src/context-runners/validate.spec.ts
+++ b/src/context-runners/validate.spec.ts
@@ -1,4 +1,5 @@
-import { Validate, toString } from './validate';
+import { Validate } from './validate';
+import { toString } from '../utils';
 import { Request } from '../base';
 import { Context } from '../context';
 import { FieldInstance } from './context-runner';

--- a/src/context-runners/validate.spec.ts
+++ b/src/context-runners/validate.spec.ts
@@ -150,9 +150,12 @@ describe('standard validator string conversion', () => {
 
   it('works from array', async () => {
     fieldInstances[0].value = ['foo'];
+    fieldInstances[1].value = ['foo', 'bar'];
     await runner.run(req, context, fieldInstances);
 
-    expect(validator).toHaveBeenCalledWith('foo');
+    expect(validator).toHaveBeenNthCalledWith(1, 'foo');
+    // TODO Should 2+ arrays be narrowed down to the first item of the array?
+    expect(validator).toHaveBeenNthCalledWith(2, 'foo');
   });
 
   it('works from object with toString', async () => {

--- a/src/context-runners/validate.ts
+++ b/src/context-runners/validate.ts
@@ -1,25 +1,12 @@
 import { Context } from '../context';
 import { ContextRunner, FieldInstance } from './context-runner';
 import { Request, ValidationError } from '../base';
+import { toString } from '../utils';
 
 class UnknownError extends Error {
   constructor() {
     super();
   }
-}
-
-export function toString(value: any, deep = true): string {
-  if (Array.isArray(value) && value.length && deep) {
-    return toString(value[0], false);
-  } else if (value instanceof Date) {
-    return value.toISOString();
-  } else if (value && typeof value === 'object' && value.toString) {
-    return value.toString();
-  } else if (value == null || (isNaN(value) && !value.length)) {
-    return '';
-  }
-
-  return String(value);
 }
 
 export class Validate implements ContextRunner {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,3 +9,17 @@ export const bindAll = <T>(object: T): { [K in keyof T]: T[K] } => {
 
   return object;
 };
+
+export function toString(value: any, deep = true): string {
+  if (Array.isArray(value) && value.length && deep) {
+    return toString(value[0], false);
+  } else if (value instanceof Date) {
+    return value.toISOString();
+  } else if (value && typeof value === 'object' && value.toString) {
+    return value.toString();
+  } else if (value == null || (isNaN(value) && !value.length)) {
+    return '';
+  }
+
+  return String(value);
+}


### PR DESCRIPTION
**This is a breaking change**

Now non-string values can finally be sanitized, woo!
Closes #641, closes #632, fixes #630, fixes #580, fixes #651