### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/api-validation-chain.md
+++ b/docs/api-validation-chain.md
@@ -122,7 +122,7 @@ check('weekday').not().isIn(['sunday', 'saturday'])
 > *Returns:* the current validation chain instance
 
 Marks the current validation chain as optional.  
-This is useful to remove values that are not essential to your busines and that would cause validation failures in case they were not provided in the request.
+This is useful to remove values that are not essential to your business and that would cause validation failures in case they were not provided in the request.
 
 By default, fields with `undefined` values will be ignored from the validation.
 


### PR DESCRIPTION
Fix typo `busines` => `business`.