### PR TITLE
Update feature-custom-validators-sanitizers.md

### DIFF
--- a/website/versioned_docs/version-6.0.0/feature-custom-validators-sanitizers.md
+++ b/website/versioned_docs/version-6.0.0/feature-custom-validators-sanitizers.md
@@ -36,7 +36,7 @@ app.post('/user', body('email').custom(value => {
 ```js
 const { body } = require('express-validator');
 
-app.post('/user', body('passwordConfirmation').custom((value, { req }) => {
+app.post('/user', body('passwordConfirmation').not().custom((value, { req }) => {
   if (value !== req.body.password) {
     throw new Error('Password confirmation does not match password');
   }


### PR DESCRIPTION
The code for checking if password confirmation matches password does not behave expected as it always returns false even when it matches. Adding `.not()` before .custom() solves the issue.