### PR TITLE
Implement .bail()

### DIFF
--- a/docs/api-validation-chain.md
+++ b/docs/api-validation-chain.md
@@ -38,6 +38,27 @@ app.post('/create-user', [
 In addition to the standard validators and the [Sanitization Chain API](api-sanitization-chain.md),
 the following methods are also available within a Validation Chain:
 
+### `.bail()`
+> *Returns:* the current validation chain instance
+
+Stops running validations if any of the previous ones have failed.  
+Useful to prevent a custom validator that touches a database or external API from running when you
+know it will fail.
+
+`.bail()` can be used multiple times in the same validation chain if needed:
+
+```js
+app.post('/', [
+  check('username')
+    .isEmail()
+    .bail()
+    // If username is not an email, checkBlacklistedDomain will never run
+    .custom(checkBlacklistedDomain)
+    // If username is not an email or has a blacklisted domain, checkEmailExists will never run
+    .custom(checkEmailExists);
+]);
+```
+
 ### `.custom(validator)`
 - `validator(value, { req, location, path })`: the custom validator function.  
 Receives the value of the field being validated, as well as the express request, the location and the field path.

--- a/src/chain/context-handler-impl.spec.ts
+++ b/src/chain/context-handler-impl.spec.ts
@@ -1,6 +1,7 @@
 import { ContextBuilder } from '../context-builder';
 import { ChainCondition, CustomCondition } from '../context-items';
 import { check } from '../middlewares/check';
+import { Bail } from '../context-items/bail';
 import { ContextHandler, ContextHandlerImpl } from './';
 
 let builder: ContextBuilder;
@@ -12,6 +13,13 @@ beforeEach(() => {
   jest.spyOn(builder, 'addItem');
 
   contextHandler = new ContextHandlerImpl(builder, {});
+});
+
+describe('#bail()', () => {
+  it('adds a Bail item', () => {
+    contextHandler.bail();
+    expect(builder.addItem).toHaveBeenCalledWith(new Bail());
+  });
 });
 
 describe('#if()', () => {

--- a/src/chain/context-handler-impl.ts
+++ b/src/chain/context-handler-impl.ts
@@ -2,11 +2,17 @@ import { ContextBuilder } from '../context-builder';
 import { Optional } from '../context';
 import { ChainCondition, CustomCondition } from '../context-items';
 import { CustomValidator } from '../base';
+import { Bail } from '../context-items/bail';
 import { ContextHandler } from './context-handler';
 import { ValidationChain } from './validation-chain';
 
 export class ContextHandlerImpl<Chain> implements ContextHandler<Chain> {
   constructor(private readonly builder: ContextBuilder, private readonly chain: Chain) {}
+
+  bail() {
+    this.builder.addItem(new Bail());
+    return this.chain;
+  }
 
   if(condition: CustomValidator | ValidationChain) {
     if ('run' in condition) {

--- a/src/chain/context-handler.ts
+++ b/src/chain/context-handler.ts
@@ -3,6 +3,7 @@ import { Optional } from '../context';
 import { ValidationChain } from './validation-chain';
 
 export interface ContextHandler<Chain> {
+  bail(): Chain;
   if(condition: CustomValidator | ValidationChain): Chain;
   optional(options?: Partial<Optional> | true): Chain;
 }

--- a/src/context-items/bail.spec.ts
+++ b/src/context-items/bail.spec.ts
@@ -1,0 +1,19 @@
+import { ContextBuilder } from '../context-builder';
+import { ValidationHalt } from '../base';
+import { Bail } from './bail';
+
+it('does not throw if the context has no errors', () => {
+  const context = new ContextBuilder().build();
+  return expect(new Bail().run(context)).resolves.toBeUndefined();
+});
+
+it('throws a validation halt if the context has errors', () => {
+  const context = new ContextBuilder().build();
+  context.addError('foo', 'value', {
+    req: {},
+    location: 'body',
+    path: 'bar',
+  });
+
+  expect(() => new Bail().run(context)).toThrowError(ValidationHalt);
+});

--- a/src/context-items/bail.ts
+++ b/src/context-items/bail.ts
@@ -1,0 +1,13 @@
+import { Context } from '../context';
+import { ValidationHalt } from '../base';
+import { ContextItem } from './context-item';
+
+export class Bail implements ContextItem {
+  run(context: Context) {
+    if (context.errors.length > 0) {
+      throw new ValidationHalt();
+    }
+
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
Supersedes #500

Stops validation if there's an error.
Logic for stopping validation reused from conditional validation, in #658.