### PR TITLE
Fix typing for optional

### DIFF
--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -146,7 +146,7 @@ describe('on each field', () => {
   });
 
   it('can be marked as optional', () => {
-    const chain = checkSchema({
+    const schema = checkSchema({
       foo: {
         optional: true,
       },
@@ -158,11 +158,16 @@ describe('on each field', () => {
           },
         },
       },
-    })[0];
+    });
 
-    expect(chainToContext(chain).optional).toEqual({
+    expect(chainToContext(schema[0]).optional).toEqual({
       checkFalsy: false,
       nullable: false,
+    });
+    
+    expect(chainToContext(schema[1]).optional).toEqual({
+      checkFalsy: true,
+      nullable: true,
     });
   });
 

--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -164,7 +164,7 @@ describe('on each field', () => {
       checkFalsy: false,
       nullable: false,
     });
-    
+
     expect(chainToContext(schema[1]).optional).toEqual({
       checkFalsy: true,
       nullable: true,

--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -150,6 +150,14 @@ describe('on each field', () => {
       foo: {
         optional: true,
       },
+      bar: {
+        optional: {
+          options: {
+            checkFalsy: true,
+            nullable: true,
+          },
+        },
+      },
     })[0];
 
     expect(chainToContext(chain).optional).toEqual({

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -32,7 +32,14 @@ type InternalParamSchema = ValidatorsSchema & SanitizersSchema;
 export type ParamSchema = InternalParamSchema & {
   in?: Location | Location[];
   errorMessage?: DynamicMessageCreator | any;
-  optional?: Partial<Optional> | true;
+  optional?: 
+    | true
+    | {
+        options?: {
+          checkFalsy?: boolean;
+          nullable?: boolean;
+        }
+      };
 };
 
 /**

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -35,10 +35,7 @@ export type ParamSchema = InternalParamSchema & {
   optional?: 
     | true
     | {
-        options?: {
-          checkFalsy?: boolean;
-          nullable?: boolean;
-        }
+        options?: Partial<Optional>
       };
 };
 

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -32,10 +32,10 @@ type InternalParamSchema = ValidatorsSchema & SanitizersSchema;
 export type ParamSchema = InternalParamSchema & {
   in?: Location | Location[];
   errorMessage?: DynamicMessageCreator | any;
-  optional?: 
+  optional?:
     | true
     | {
-        options?: Partial<Optional>
+        options?: Partial<Optional>;
       };
 };
 


### PR DESCRIPTION
There's a bug in the typings when marking a field as optional.
For example, this flags as an error
```javascript
checkSchema({
  foo: {
    optional: {
      options: {
        nullable: true,
        checkFalsy: true,
      }
    }
  }
})
```

but allows the following:

```javascript
checkSchema({
  foo: {
    optional: {
      nullable: true,
      checkFalsy: true,
    }
  }
})
```

However, this has no effect.

This has been addressed previously in #693 but it looks like this has been regressed.

Also see #742