### PR TITLE
Update mobile phone locale options (#772)

### DIFF
--- a/src/chain/validators-impl.spec.ts
+++ b/src/chain/validators-impl.spec.ts
@@ -148,25 +148,6 @@ describe('#isString()', () => {
   });
 });
 
-describe('#isMobilePhone()', () => {
-  it('checks if context is a valid mobile phone for pt-BR locale', async () => {
-    validators.isMobilePhone('pt-BR');
-    const context = builder.build();
-
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
-    const isMobilePhone = context.stack[0];
-
-    await isMobilePhone.run(context, '011990000000', meta);
-    expect(context.errors).toHaveLength(0);
-
-    await isMobilePhone.run(context, null, meta);
-    await isMobilePhone.run(context, undefined, meta);
-    await isMobilePhone.run(context, '', meta);
-    await isMobilePhone.run(context, '123456789', meta);
-    expect(context.errors).toHaveLength(4);
-  });
-});
-
 describe('#isArray()', () => {
   it('adds custom validator to the context', () => {
     const ret = validators.isArray();

--- a/src/chain/validators-impl.spec.ts
+++ b/src/chain/validators-impl.spec.ts
@@ -148,6 +148,25 @@ describe('#isString()', () => {
   });
 });
 
+describe('#isMobilePhone()', () => {
+  it('checks if context is a valid mobile phone for pt-BR locale', async () => {
+    validators.isMobilePhone('pt-BR');
+    const context = builder.build();
+
+    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const isMobilePhone = context.stack[0];
+
+    await isMobilePhone.run(context, '011990000000', meta);
+    expect(context.errors).toHaveLength(0);
+
+    await isMobilePhone.run(context, null, meta);
+    await isMobilePhone.run(context, undefined, meta);
+    await isMobilePhone.run(context, '', meta);
+    await isMobilePhone.run(context, '123456789', meta);
+    expect(context.errors).toHaveLength(4);
+  });
+});
+
 describe('#isArray()', () => {
   it('adds custom validator to the context', () => {
     const ret = validators.isArray();

--- a/src/options.ts
+++ b/src/options.ts
@@ -171,6 +171,7 @@ export type MobilePhoneLocale =
   | 'nl-NL'
   | 'nn-NO'
   | 'pl-PL'
+  | 'pt-BR'
   | 'pt-PT'
   | 'ro-RO'
   | 'ru-RU'


### PR DESCRIPTION
This pull request updates the mobile phone locale by adding the `pt-BR' option, as the validator.js library already has this option for use.

Resolves #772 