### PR TITLE
Fix error where property 'value' does not exist on type 'ValidationError’

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -21,19 +21,20 @@ export interface FieldInstance {
 
 export type ValidationError =
   | {
-      // It's optional and undefined so places don't need to define it, but can reference it
-      location?: undefined;
       param: '_error';
       msg: any;
       nestedErrors: ValidationError[];
-      value?: any;
+      // These are optional so places don't need to define them, but can reference them
+      location?: undefined;
+      value?: undefined;
     }
   | {
       location: Location;
       param: string;
       value: any;
       msg: any;
-      nestedErrors?: ValidationError[];
+      // This is optional so places don't need to define it, but can reference it
+      nestedErrors?: unknown[];
     };
 
 export interface Request {

--- a/src/base.ts
+++ b/src/base.ts
@@ -26,12 +26,14 @@ export type ValidationError =
       param: '_error';
       msg: any;
       nestedErrors: ValidationError[];
+      value?: any;
     }
   | {
       location: Location;
       param: string;
       value: any;
       msg: any;
+      nestedErrors?: ValidationError[];
     };
 
 export interface Request {


### PR DESCRIPTION
# What went wrong?

Accessing property in union of object types fails for properties not defined on all union members.
```
error TS2339: Property 'value' does not exist on type 'ValidationError'.
  Property 'value' does not exist on type '{ location?: undefined; param: "_error"; msg: any; nestedErrors: ValidationError[]; }'.
```
# Proposed Fix

Add optional types to all validation error fields for each union member. Fixes https://github.com/express-validator/express-validator/issues/795.

# Related Issue

https://github.com/Microsoft/TypeScript/issues/12815

# Environment

TypeScript v3.7.2
