### PR TITLE
matchedData: consider unused fields as optional data

### DIFF
--- a/src/context-items/custom-validation.ts
+++ b/src/context-items/custom-validation.ts
@@ -8,6 +8,7 @@ export class CustomValidation implements ContextItem {
   constructor(private readonly validator: CustomValidator, private readonly negated: boolean) {}
 
   async run(context: Context, value: any, meta: Meta) {
+    context.markAsUsed(meta.path, meta.location);
     try {
       const result = this.validator(value, meta);
       const actualResult = await result;

--- a/src/context-items/sanitization.ts
+++ b/src/context-items/sanitization.ts
@@ -13,6 +13,7 @@ export class Sanitization implements ContextItem {
 
   async run(context: Context, value: any, meta: Meta) {
     const { req, path, location } = meta;
+    context.markAsUsed(path, location);
 
     const newValue = this.custom
       ? (this.sanitizer as CustomSanitizer)(value, meta)

--- a/src/context-items/standard-validation.ts
+++ b/src/context-items/standard-validation.ts
@@ -13,6 +13,8 @@ export class StandardValidation implements ContextItem {
   ) {}
 
   async run(context: Context, value: any, meta: Meta) {
+    context.markAsUsed(meta.path, meta.location);
+
     const result = this.validator(toString(value), ...this.options);
     if (this.negated ? result : !result) {
       context.addError(this.message, value, meta);

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,6 +15,7 @@ export class Context {
   }
 
   private readonly dataMap: Map<string, FieldInstance> = new Map();
+  private readonly dataUseCount: Map<string, number> = new Map();
 
   constructor(
     readonly fields: string[],
@@ -72,6 +73,16 @@ export class Context {
     instance.value = value;
   }
 
+  markAsUsed(path: string, location: Location) {
+    const key = getDataMapKey(path, location);
+    this.dataUseCount.set(key, (this.dataUseCount.get(key) || 0) + 1);
+  }
+
+  getUseCount(path: string, location: Location) {
+    const key = getDataMapKey(path, location);
+    return this.dataUseCount.get(key) || 0;
+  }
+
   addError(message: any, value: any, meta: Meta): void;
   addError(message: any, nestedErrors: ValidationError[]): void;
   addError(message: any, valueOrNestedErrors: any, meta?: Meta) {
@@ -95,5 +106,5 @@ export class Context {
 
 export type ReadonlyContext = Pick<
   Context,
-  Exclude<keyof Context, 'setData' | 'addFieldInstances' | 'addError'>
+  Exclude<keyof Context, 'setData' | 'addFieldInstances' | 'addError' | 'markAsUsed'>
 >;

--- a/src/matched-data.spec.ts
+++ b/src/matched-data.spec.ts
@@ -62,6 +62,41 @@ it('does not include valid data from invalid oneOf() chain group', done => {
   });
 });
 
+describe('with chains that contain .if()', () => {
+  it('does not include data of chain with early failed condition', done => {
+    const req = {
+      query: { foo: 'foo' },
+    };
+
+    const middleware = check('foo')
+      .if((value: any) => /\d/.test(value))
+      .equals('foo');
+
+    middleware(req, {}, () => {
+      expect(matchedData(req)).toEqual({});
+      done();
+    });
+  });
+
+  it('includes data of chain with late failed condition', done => {
+    const req = {
+      query: { foo: 'foo' },
+    };
+
+    const middleware = check('foo')
+      .equals('foo')
+      .if((value: any) => /\d/.test(value))
+      .isInt();
+
+    middleware(req, {}, () => {
+      expect(matchedData(req)).toEqual({
+        foo: 'foo',
+      });
+      done();
+    });
+  });
+});
+
 describe('when option includeOptionals is true', () => {
   it('returns object with optional data', done => {
     const req = {
@@ -108,7 +143,7 @@ describe('when option locations is defined', () => {
       query: { baz: true },
     };
 
-    check(['foo', 'bar', 'baz'])(req, {}, () => {
+    check(['foo', 'bar', 'baz']).exists()(req, {}, () => {
       const data = matchedData(req, {
         locations: ['params', 'query'],
       });

--- a/src/matched-data.ts
+++ b/src/matched-data.ts
@@ -32,10 +32,14 @@ export function matchedData(
     .valueOf();
 }
 
-function createFieldExtractor(removeOptionals: boolean) {
+function createFieldExtractor(requiredOnly: boolean) {
   return (context: Context) => {
-    const instances = context.getData({ requiredOnly: removeOptionals });
-    return instances.map((instance): FieldInstanceBag => ({ instance, context }));
+    const instances = context.getData({ requiredOnly });
+    return instances
+      .filter(
+        instance => !requiredOnly || context.getUseCount(instance.path, instance.location) > 0,
+      )
+      .map((instance): FieldInstanceBag => ({ instance, context }));
   };
 }
 

--- a/src/middlewares/one-of.ts
+++ b/src/middlewares/one-of.ts
@@ -27,7 +27,11 @@ export function oneOf(chains: (ValidationChain | ValidationChain[])[], message?:
       // if its entire group is valid.
       if (!groupErrors.length) {
         contexts.forEach(context => {
-          surrogateContext.addFieldInstances(context.getData());
+          const instances = context.getData();
+          surrogateContext.addFieldInstances(instances);
+          instances.forEach(instance => {
+            surrogateContext.markAsUsed(instance.path, instance.location);
+          });
         });
       }
 


### PR DESCRIPTION
Adds an API in the context to mark fields as used, and use that in `matchedData` to treat unused ones as optional.

**This is a breaking change.** Chains that have no validators or sanitizers will no longer be included in the result of `matchedData()` by default.

Fixes #819