### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -2,7 +2,10 @@
 const siteConfig = {
   algolia: {
     apiKey: 'd6d85148b3b81778cf952442d4292bea',
-    indexName: 'express-validator'
+    indexName: 'express-validator',
+    algoliaOptions: {
+      facetFilters: ['type:lvl3', 'language:LANGUAGE', 'version:VERSION'],
+    },
   },
   // Metadata
   title: 'express-validator',

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,5 +1,9 @@
 // See https://docusaurus.io/docs/site-config.html for all the possible site configuration options.
 const siteConfig = {
+  algolia: {
+    apiKey: 'd6d85148b3b81778cf952442d4292bea',
+    indexName: 'express-validator'
+  },
   // Metadata
   title: 'express-validator',
   tagline: 'express-validator docs',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.