### PR TITLE
Made customSanitizer await for async functions

### DIFF
--- a/src/chain/sanitizers-impl.spec.ts
+++ b/src/chain/sanitizers-impl.spec.ts
@@ -81,6 +81,24 @@ describe('#customSanitizer()', () => {
     expect(ret).toBe(chain);
     expect(builder.addItem).toHaveBeenCalledWith(new Sanitization(sanitizer, true));
   });
+
+  it('adds a custom async sanitizer that resolves to the context', () => {
+    const sanitizer = jest.fn(async () => 1);
+    const ret = sanitizers.customSanitizer(sanitizer);
+
+    expect(ret).toBe(chain);
+    expect(builder.addItem).toHaveBeenCalledWith(new Sanitization(sanitizer, true));
+  });
+
+  it('adds a custom async sanitizer that rejects to the context', () => {
+    const sanitizer = jest.fn(async () => {
+      throw new Error('Dummy Error');
+    });
+    const ret = sanitizers.customSanitizer(sanitizer);
+
+    expect(ret).toBe(chain);
+    expect(builder.addItem).toHaveBeenCalledWith(new Sanitization(sanitizer, true));
+  });
 });
 
 describe('#toArray()', () => {

--- a/src/context-items/sanitization.spec.ts
+++ b/src/context-items/sanitization.spec.ts
@@ -42,6 +42,15 @@ describe('when sanitizer is a custom one', () => {
 
     expect(sanitizer).toHaveBeenCalledWith('foo', meta);
   });
+
+  it('calls it with the value of an async function and the meta', async () => {
+    sanitizer = jest.fn(async value => 'foo ' + value);
+    sanitization = new Sanitization(sanitizer, true);
+    await sanitization.run(context, 'bar', meta);
+
+    expect(sanitizer).toHaveBeenCalledWith('bar', meta);
+    expect(context.getData()[0].value).toBe('foo bar');
+  });
 });
 
 describe('when sanitizer is a standard one', () => {

--- a/src/context-items/sanitization.ts
+++ b/src/context-items/sanitization.ts
@@ -13,8 +13,16 @@ export class Sanitization implements ContextItem {
   async run(context: Context, value: any, meta: Meta) {
     const { path, location } = meta;
 
+    const runCustomSanitizer = async () => {
+      const sanitizerValue = this.sanitizer(value, meta);
+      if (sanitizerValue instanceof Promise) {
+        return await sanitizerValue;
+      }
+      return sanitizerValue;
+    };
+
     const newValue = this.custom
-      ? (this.sanitizer as CustomSanitizer)(value, meta)
+      ? await runCustomSanitizer()
       : (this.sanitizer as StandardSanitizer)(toString(value), ...this.options);
 
     context.setData(path, newValue, location);

--- a/src/context-items/sanitization.ts
+++ b/src/context-items/sanitization.ts
@@ -15,10 +15,7 @@ export class Sanitization implements ContextItem {
 
     const runCustomSanitizer = async () => {
       const sanitizerValue = this.sanitizer(value, meta);
-      if (sanitizerValue instanceof Promise) {
-        return await sanitizerValue;
-      }
-      return sanitizerValue;
+      return Promise.resolve(sanitizerValue);
     };
 
     const newValue = this.custom


### PR DESCRIPTION
I made this little tweak to make possible use customSanitize in async environments. I did not made a proper error handler because I don't know how to integrate that with the validators, so I don't think the work of this feature is done, that's just a draft. This is related to #784 

An example use case for this would be: ``body('user').customSanitizer(async(id) => await users.findById(id))``

Also made the tests for that