### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a reproducible bug or regression.
+title: 'Bug:'
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+## To Reproduce
+<!-- Steps to reproduce the behavior -->
+1. <!-- Go to '...' -->
+2. <!-- Click on '...' -->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Current behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Express-validator version:
+ - Version: <!-- [e.g. 6.6.1] -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Description
+<!-- Describe what you changed and link to the relevant issue(s) -->
+
+## To-do list
+
+<!-- Put an "x" to indicate you've done each of the following -->
+- [ ] I have added tests for what I changed.
+
+<!-- If this pull request isn't ready, add any remaining tasks here -->
+- [ ] This pull request is ready to merge.


### PR DESCRIPTION
This PR adds issue and pull request templates. Templates give suggestions on what information need to be specified in a pull request or in an issue.
This closes #922 