### PR TITLE
Fix: Updated IsAlphaOptions.ignore to allow string or RegExp

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -394,7 +394,7 @@ export interface ContainsOptions {
 }
 
 export interface IsAlphaOptions {
-  ignore?: string[];
+  ignore?: string[] | RegExp;
 }
 
 /**


### PR DESCRIPTION
## Description

I was having issues with using a RegExp for the `ignore` property on `IsAlphaOptions`.

<img width="1110" alt="Screen Shot 2020-12-22 at 5 28 35 PM" src="https://user-images.githubusercontent.com/1715082/102943635-34f56e80-447e-11eb-803d-6ab9613192ed.png">

I'm using the latest version of **express-validator**:

```sh
╭─iamwillshepherd@ares ~/code/code-in-color/apli/server ‹applicants-need-love-too›
╰─$ cat package.json | grep "express-validator"
    "express-validator": "^6.8.1",
```

I checked your `package.json` file and noticed y'all are depending on the latest release of `validator`.

https://github.com/express-validator/express-validator/blob/9b74459152fe0528eaacb79d473a942cb4b8e56a/package.json#L44-L47

If you head over to the test suite of validatorjs/validator, you'll notice that `isAlpha` accepts a `string` **or** `RegExp`

https://github.com/validatorjs/validator.js/blob/8831db31e7d5de03cb9744f811ffd256494f97f6/test/validators.js#L991-L1003 

So, I updated the type signature of `IsAlphaOptions` to accept a `RegExp`. 

I've updated your types locally to unblock myself, but I'd rather have this change in the main project so others don't have a wtf moment as well.


## To-do list

I did not add any tests because I made type changes. The test suite doesn't take types into account, so I didn't feel it was worth the effort.

<!-- Put an "x" to indicate you've done each of the following -->
- ~[ ] I have added tests for what I changed.~
- [x] This pull request is ready to merge.