### PR TITLE
fix(IsAlphaOptions.ignore): convert 'string[]' to 'string'

### DIFF
--- a/src/chain/validators-impl.spec.ts
+++ b/src/chain/validators-impl.spec.ts
@@ -121,6 +121,17 @@ describe('#exists()', () => {
   });
 });
 
+describe('#isAlpha()', () => {
+  it('checks options.ignore transformation from string[] to string', () => {
+    const ret = validators.isAlpha('it-IT', { ignore: ['b', 'a', 'r'] });
+
+    expect(ret).toBe(chain);
+    expect(builder.addItem).toHaveBeenCalledWith(
+      new StandardValidation(validator.isAlpha, false, ['it-IT', { ignore: 'bar' }]),
+    );
+  });
+});
+
 describe('#isString()', () => {
   it('adds custom validator to the context', () => {
     const ret = validators.isString();

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -82,7 +82,9 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     return this.addStandardValidation(validator.isAfter, date);
   }
   isAlpha(locale?: Options.AlphaLocale, options?: Options.IsAlphaOptions) {
-    return this.addStandardValidation(validator.isAlpha, locale, options);
+    const ignore = Array.isArray(options?.ignore) ? options?.ignore.join('') : options?.ignore;
+    delete options?.ignore;
+    return this.addStandardValidation(validator.isAlpha, locale, { ...options, ignore });
   }
   isAlphanumeric(locale?: Options.AlphanumericLocale) {
     return this.addStandardValidation(validator.isAlphanumeric, locale);

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -83,7 +83,6 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
   }
   isAlpha(locale?: Options.AlphaLocale, options?: Options.IsAlphaOptions) {
     const ignore = Array.isArray(options?.ignore) ? options?.ignore.join('') : options?.ignore;
-    delete options?.ignore;
     return this.addStandardValidation(validator.isAlpha, locale, { ...options, ignore });
   }
   isAlphanumeric(locale?: Options.AlphanumericLocale) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -394,7 +394,7 @@ export interface ContainsOptions {
 }
 
 export interface IsAlphaOptions {
-  ignore?: string[] | RegExp;
+  ignore?: string | RegExp;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -394,7 +394,7 @@ export interface ContainsOptions {
 }
 
 export interface IsAlphaOptions {
-  ignore?: string[] | RegExp;
+  ignore?: string | string[] | RegExp;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -394,7 +394,7 @@ export interface ContainsOptions {
 }
 
 export interface IsAlphaOptions {
-  ignore?: string | RegExp;
+  ignore?: string[] | RegExp;
 }
 
 /**


### PR DESCRIPTION
## Description

This addresses a type bug introduced in #952.

https://github.com/express-validator/express-validator/pull/963#issuecomment-752722295

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
