### PR TITLE
feat: add 'rename' context-item

### DIFF
--- a/src/chain/context-handler-impl.spec.ts
+++ b/src/chain/context-handler-impl.spec.ts
@@ -3,6 +3,7 @@ import { ChainCondition, CustomCondition } from '../context-items';
 import { check } from '../middlewares/check';
 import { Bail } from '../context-items/bail';
 import { ContextHandler, ContextHandlerImpl } from './';
+import { Rename } from '../context-items/rename';
 
 let builder: ContextBuilder;
 let contextHandler: ContextHandler<any>;
@@ -72,5 +73,12 @@ describe('#optional()', () => {
 
     contextHandler.optional(false);
     expect(builder.setOptional).toHaveBeenNthCalledWith(3, false);
+  });
+});
+
+describe('#rename()', () => {
+  it('adds a Rename item', () => {
+    contextHandler.rename('foo');
+    expect(builder.addItem).toHaveBeenCalledWith(new Rename('foo'));
   });
 });

--- a/src/chain/context-handler-impl.ts
+++ b/src/chain/context-handler-impl.ts
@@ -3,6 +3,7 @@ import { Optional } from '../context';
 import { ChainCondition, CustomCondition } from '../context-items';
 import { CustomValidator } from '../base';
 import { Bail } from '../context-items/bail';
+import { Rename } from '../context-items/rename';
 import { ContextHandler } from './context-handler';
 import { ValidationChain } from './validation-chain';
 
@@ -35,6 +36,11 @@ export class ContextHandlerImpl<Chain> implements ContextHandler<Chain> {
       });
     }
 
+    return this.chain;
+  }
+
+  rename(newPath: string) {
+    this.builder.addItem(new Rename(newPath));
     return this.chain;
   }
 }

--- a/src/chain/context-handler.ts
+++ b/src/chain/context-handler.ts
@@ -6,4 +6,5 @@ export interface ContextHandler<Chain> {
   bail(): Chain;
   if(condition: CustomValidator | ValidationChain): Chain;
   optional(options?: Partial<Optional> | true): Chain;
+  rename(newPath: string): Chain;
 }

--- a/src/context-items/rename.spec.ts
+++ b/src/context-items/rename.spec.ts
@@ -1,0 +1,67 @@
+import { ContextBuilder } from '../context-builder';
+import { Meta } from '../base';
+import { Rename } from './rename';
+
+it('the new path is identical to the old one', () => {
+  const context = new ContextBuilder().build();
+  const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+
+  expect(new Rename('foo').run(context, 'value', meta)).resolves;
+});
+
+it('throws an error if trying to rename more than one field', async () => {
+  const context = new ContextBuilder().setFields(['foo', 'bar']).build();
+  const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+
+  await expect(new Rename('_foo').run(context, 'value', meta)).rejects.toThrow();
+});
+
+describe('throws an error if using wildcards', () => {
+  it('in context fields', async () => {
+    const context = new ContextBuilder().setFields(['foo.*']).build();
+    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+
+    await expect(new Rename('_foo').run(context, 'value', meta)).rejects.toThrow();
+  });
+
+  it('in new path', async () => {
+    const context = new ContextBuilder().setFields(['foo']).build();
+    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+
+    await expect(new Rename('foo.*').run(context, 'value', meta)).rejects.toThrow();
+  });
+});
+
+it('throws an error if the new path is already assigned to a property', async () => {
+  const context = new ContextBuilder().setFields(['foo']).build();
+  const meta: Meta = {
+    req: {
+      body: {
+        foo: 'value',
+        _foo: 'bar',
+      },
+    },
+    location: 'body',
+    path: 'foo',
+  };
+
+  await expect(new Rename('_foo').run(context, 'value', meta)).rejects.toThrow();
+});
+
+it('throws an error if trying to rename to an existing property', () => {
+  const context = new ContextBuilder().setFields(['foo']).build();
+  const meta: Meta = {
+    req: {
+      body: {
+        foo: 'value',
+      },
+    },
+    location: 'body',
+    path: 'foo',
+  };
+
+  expect(new Rename('_foo').run(context, 'value', meta)).resolves;
+  expect(meta.req.body).toEqual({
+    _foo: 'value',
+  });
+});

--- a/src/context-items/rename.ts
+++ b/src/context-items/rename.ts
@@ -1,0 +1,30 @@
+import * as _ from 'lodash';
+import { Meta } from '../base';
+import { Context } from '../context';
+import { ContextItem } from './context-item';
+
+export class Rename implements ContextItem {
+  constructor(readonly newPath: string) {}
+
+  async run(context: Context, value: any, meta: Meta) {
+    const { req, location, path } = meta;
+
+    if (path !== this.newPath) {
+      if (context.fields.length !== 1) {
+        throw new Error('Cannot rename multiple fields.');
+      }
+      const field = context.fields[0];
+      if (field.includes('*') || this.newPath.includes('*')) {
+        throw new Error('Cannot use rename() with wildcards.');
+      }
+
+      if (_.get(req[location], this.newPath) !== undefined) {
+        throw new Error(`Cannot rename to req.${location}.${path} as it already exists.`);
+      }
+
+      _.set(req[location], this.newPath, value);
+      _.unset(req[location], path);
+    }
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
## Description
This allows to rename a property.

```js
// req: { body: { name: 'foo' } } becomes 
// req: { body: { username: 'foo' } }
body('name').rename('username').isString()

// req: { body: { names: ['foo', 'bar'] } } throws
body('names.*').rename('username').isString()

// req: { body: { name: 'foo', surname: 'bar' } } throws
body(['name', 'surname']).rename('username')

// req: { body: { name: 'foo', surname: 'bar' } } throws
body('name').rename('surname')
```


Closes #785 

<!-- Describe what you changed and link to the relevant issue(s) -->

## To-do list

- [ ] Work on returned errors
- [ ] Wildcards?
- [ ] Dotted property names (e.g. `1.0`)

---
<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [ ] This pull request is ready to merge.
