### PR TITLE
fix(toString): no longer throwing with custom Object.toString

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -10,7 +10,7 @@ describe('#toString', () => {
     expect(toString(value)).toEqual('foo');
   });
 
-  it('test custom object toString not "function"', () => {
+  it('calls Object.prototype.toString() when custom one is not function', () => {
     const value = {
       toString: 'something',
     };

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,7 +1,7 @@
 import { toString } from './utils';
 
 describe('#toString', () => {
-  it('test custom object toString function', () => {
+  it('calls custom toString function', () => {
     const value = {
       toString() {
         return 'foo';

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,28 @@
+import { toString } from './utils';
+
+describe('#toString', () => {
+  it('test custom object toString function', () => {
+    const value = {
+      toString() {
+        return 'foo';
+      },
+    };
+    expect(toString(value)).toEqual('foo');
+  });
+
+  it('test custom object toString not "function"', () => {
+    const value = {
+      toString: 'something',
+    };
+
+    expect(toString(value)).toEqual('[object Object]');
+  });
+
+  it('test missing object toString', () => {
+    const value = {
+      foo: 'foo',
+    };
+
+    expect(toString(value)).toEqual('[object Object]');
+  });
+});

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -18,7 +18,7 @@ describe('#toString', () => {
     expect(toString(value)).toEqual('[object Object]');
   });
 
-  it('test missing object toString', () => {
+  it('calls Object.prototype.toString() when passed object does not have a toString function', () => {
     const value = {
       foo: 'foo',
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,9 @@ export function toString(value: any, deep = true): string {
   } else if (value instanceof Date) {
     return value.toISOString();
   } else if (value && typeof value === 'object' && value.toString) {
+    if (typeof value.toString !== 'function') {
+      return Object.getPrototypeOf(value).toString.call(value);
+    }
     return value.toString();
   } else if (value == null || (isNaN(value) && !value.length)) {
     return '';


### PR DESCRIPTION
## Description
https://github.com/express-validator/express-validator/issues/791#issuecomment-752924430

```js
const value = {
  toString: 'something',
};

// returns '[object Object]' instead of throwing
const v = toString(value)

```
## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
