### PR TITLE
feat: add 'isObject' validator

### DIFF
--- a/docs/api-validation-chain.md
+++ b/docs/api-validation-chain.md
@@ -151,6 +151,15 @@ body('oldPassword')
 
 Adds a validator to check if a value is an array.
 
+### `.isObject(options)`
+
+- `options` _(optional)_: an object which accepts the following options:
+  - `strict`: If set to `false` the validation passes also for `array` and `null` types (defaults to `true`).
+
+> _Returns:_ the current validation chain instance
+
+Adds a validator to check if a value is an object.
+
 ### `.isString()`
 
 > _Returns:_ the current validation chain instance

--- a/src/chain/validators-impl.spec.ts
+++ b/src/chain/validators-impl.spec.ts
@@ -159,6 +159,55 @@ describe('#isString()', () => {
   });
 });
 
+describe('#isObject()', () => {
+  it('adds custom validator to the context', () => {
+    const ret = validators.isObject();
+
+    expect(ret).toBe(chain);
+    expect(builder.addItem).toHaveBeenCalledWith(new CustomValidation(expect.any(Function), false));
+  });
+
+  it('checks if context is object', async () => {
+    validators.isObject();
+    const context = builder.build();
+
+    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const isObject = context.stack[0];
+
+    await isObject.run(context, {}, meta);
+    await isObject.run(context, { foo: 'foo' }, meta);
+    expect(context.errors).toHaveLength(0);
+
+    await isObject.run(context, 'foo', meta);
+    await isObject.run(context, 5, meta);
+    await isObject.run(context, true, meta);
+    await isObject.run(context, null, meta);
+    await isObject.run(context, undefined, meta);
+    await isObject.run(context, ['foo'], meta);
+    expect(context.errors).toHaveLength(6);
+  });
+
+  it('checks if context is object with strict = false', async () => {
+    validators.isObject({ strict: false });
+    const context = builder.build();
+
+    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const isObject = context.stack[0];
+
+    await isObject.run(context, {}, meta);
+    await isObject.run(context, { foo: 'foo' }, meta);
+    await isObject.run(context, ['foo'], meta);
+    await isObject.run(context, null, meta);
+    expect(context.errors).toHaveLength(0);
+
+    await isObject.run(context, 'foo', meta);
+    await isObject.run(context, 5, meta);
+    await isObject.run(context, true, meta);
+    await isObject.run(context, undefined, meta);
+    expect(context.errors).toHaveLength(4);
+  });
+});
+
 describe('#isArray()', () => {
   it('adds custom validator to the context', () => {
     const ret = validators.isArray();

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -58,6 +58,14 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     );
   }
 
+  isObject(options: { strict?: boolean } = { strict: true }) {
+    return this.custom(
+      value =>
+        typeof value === 'object' &&
+        (options.strict ? value !== null && !Array.isArray(value) : true),
+    );
+  }
+
   isString() {
     return this.custom(value => typeof value === 'string');
   }

--- a/src/chain/validators.ts
+++ b/src/chain/validators.ts
@@ -11,6 +11,7 @@ export interface Validators<Return> {
   custom(validator: CustomValidator): Return;
   exists(options?: { checkFalsy?: boolean; checkNull?: boolean }): Return;
   isArray(options?: { min?: number; max?: number }): Return;
+  isObject(options?: { strict?: boolean }): Return;
   isString(): Return;
   notEmpty(options?: Options.IsEmptyOptions): Return;
 


### PR DESCRIPTION
## Description

This PR implements `isObject` validator to validate objects.
`strict` option defaults to `true` so that arrays and null values does not pass validation, but it can be marked as `false` to allow them.

Closes #882 
<!-- Describe what you changed and link to the relevant issue(s) -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
