### PR TITLE
fix(oneOf): return `Result` when running imperatively

### DIFF
--- a/docs/api-check.md
+++ b/docs/api-check.md
@@ -60,7 +60,7 @@ Same as `check([fields, message])`, but only checking `req.query`.
   or an array of arrays containing validation chains.
 - `message` _(optional)_: an error message to use when all chains failed. Defaults to `Invalid value(s)`; see also [Dynamic Messages](feature-error-messages.md#dynamic-messages).
 
-> _Returns:_ a middleware instance and `{ run: (req) => Promise<ResultWithContext> }`
+> _Returns:_ a middleware instance and `{ run: (req) => Promise<Result> }`
 
 Creates a middleware instance that will ensure at least one of the given chains passes the validation.  
 If none of the given chains passes, an error will be pushed to the `_error` pseudo-field,

--- a/docs/api-check.md
+++ b/docs/api-check.md
@@ -60,7 +60,7 @@ Same as `check([fields, message])`, but only checking `req.query`.
   or an array of arrays containing validation chains.
 - `message` _(optional)_: an error message to use when all chains failed. Defaults to `Invalid value(s)`; see also [Dynamic Messages](feature-error-messages.md#dynamic-messages).
 
-> _Returns:_ a middleware instance and `{ run: (req) => Promise<void> }`
+> _Returns:_ a middleware instance and `{ run: (req) => Promise<ResultWithContext> }`
 
 Creates a middleware instance that will ensure at least one of the given chains passes the validation.  
 If none of the given chains passes, an error will be pushed to the `_error` pseudo-field,

--- a/src/chain/context-runner-impl.ts
+++ b/src/chain/context-runner-impl.ts
@@ -6,7 +6,7 @@ import { SelectFields, selectFields as baseSelectFields } from '../select-fields
 import { Result } from '../validation-result';
 import { ContextRunner } from './context-runner';
 
-class ResultWithContext extends Result {
+export class ResultWithContext extends Result {
   constructor(readonly context: ReadonlyContext) {
     super(error => error, context.errors);
   }

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -1,5 +1,6 @@
 import { InternalRequest, contextsKey } from '../base';
-import { ContextRunnerImpl, ResultWithContext } from '../chain/context-runner-impl';
+import { ContextRunnerImpl } from '../chain/context-runner-impl';
+import { Result } from '../validation-result';
 import { check } from './validation-chain-builders';
 import { oneOf } from './one-of';
 
@@ -194,7 +195,7 @@ describe('imperatively run oneOf', () => {
     const result = await middleware.run(req);
 
     const context = getOneOfContext(req);
-    expect(result).toBeInstanceOf(ResultWithContext);
+    expect(result).toBeInstanceOf(Result);
     expect(context.errors.length).toEqual(0);
   });
 });

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -1,5 +1,5 @@
 import { InternalRequest, contextsKey } from '../base';
-import { ContextRunnerImpl } from '../chain/context-runner-impl';
+import { ContextRunnerImpl, ResultWithContext } from '../chain/context-runner-impl';
 import { check } from './validation-chain-builders';
 import { oneOf } from './one-of';
 
@@ -191,9 +191,10 @@ describe('imperatively run oneOf', () => {
     };
 
     const middleware = oneOf([check('foo').isBoolean()]);
-    await middleware.run(req);
+    const result = await middleware.run(req);
 
     const context = getOneOfContext(req);
+    expect(result).toBeInstanceOf(ResultWithContext);
     expect(context.errors.length).toEqual(0);
   });
 });

--- a/src/middlewares/one-of.ts
+++ b/src/middlewares/one-of.ts
@@ -3,7 +3,7 @@ import { ContextRunnerImpl, ValidationChain } from '../chain';
 import { InternalRequest, Middleware, Request } from '../base';
 import { ContextBuilder } from '../context-builder';
 import { ContextItem } from '../context-items';
-import { ResultWithContext } from '../chain';
+import { Result } from '../validation-result';
 
 // A dummy context item that gets added to surrogate contexts just to make them run
 const dummyItem: ContextItem = { async run() {} };
@@ -13,14 +13,14 @@ export type OneOfCustomMessageBuilder = (options: { req: Request }) => any;
 export function oneOf(
   chains: (ValidationChain | ValidationChain[])[],
   message?: OneOfCustomMessageBuilder,
-): Middleware & { run: (req: Request) => Promise<ResultWithContext> };
+): Middleware & { run: (req: Request) => Promise<Result> };
 export function oneOf(
   chains: (ValidationChain | ValidationChain[])[],
   message?: any,
-): Middleware & { run: (req: Request) => Promise<ResultWithContext> };
+): Middleware & { run: (req: Request) => Promise<Result> };
 
 export function oneOf(chains: (ValidationChain | ValidationChain[])[], message?: any) {
-  let result: ResultWithContext;
+  let result: Result;
 
   const middleware = async (req: InternalRequest, _res: any, next: (err?: any) => void) => {
     const surrogateContext = new ContextBuilder().addItem(dummyItem).build();
@@ -64,7 +64,7 @@ export function oneOf(chains: (ValidationChain | ValidationChain[])[], message?:
   };
 
   const run = async (req: Request) => {
-    return new Promise<ResultWithContext>((resolve, reject) => {
+    return new Promise<Result>((resolve, reject) => {
       middleware(req, {}, (e?: any) => {
         e ? reject(e) : resolve(result);
       });


### PR DESCRIPTION
## Description
Fixes #995 
<!-- Describe what you changed and link to the relevant issue(s) -->
~~Note that the ResultWithContext of a `ValidationChain` and `oneOf` is slightly different.~~ 
```js
// body('foo').isString().run({ req: { foo: 'foo' } })
ResultWithContext {
  formatter: [Function (anonymous)],
  errors: [
    {
      value: 'foo',
      msg: 'Invalid value',
      param: 'foo',
      location: 'body'
    }
  ],
  context: Context {
    fields: [ 'foo' ],
    locations: [ 'body' ],
    stack: [ [StandardValidation] ],
    optional: false,
    message: undefined,
    _errors: [ [Object] ],
    dataMap: Map(1) { 'body:foo' => [Object] }
  }
}
// oneOf([body('foo').isString()]).run({ req: { foo: 'foo' } })
ResultWithContext {
  formatter: [Function (anonymous)],
  errors: [
    { msg: 'Invalid value(s)', param: '_error', nestedErrors: [Array] }
  ],
  context: Context {
    fields: [],
    locations: [],
    stack: [ [Object] ],
    optional: false,
    message: undefined,
    _errors: [ [Object] ],
    dataMap: Map(0) {}
  }
}
```
---------

edit: no longer after e5e492a
## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
