### PR TITLE
chore: document why not using `Symbol` for `contextsKey`

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -48,7 +48,7 @@ export type ValidationError =
       nestedErrors?: unknown[];
     };
 
-// Not using simbols because of #813
+// Not using Symbol because of #813
 export const contextsKey = 'express-validator#contexts';
 
 export interface InternalRequest extends Request {

--- a/src/base.ts
+++ b/src/base.ts
@@ -48,7 +48,7 @@ export type ValidationError =
       nestedErrors?: unknown[];
     };
 
-export const contextsKey = 'express-validator#contexts';
+export const contextsKey = Symbol('contexts');
 
 export interface InternalRequest extends Request {
   [contextsKey]?: ReadonlyContext[];

--- a/src/base.ts
+++ b/src/base.ts
@@ -48,7 +48,8 @@ export type ValidationError =
       nestedErrors?: unknown[];
     };
 
-export const contextsKey = Symbol('contexts');
+// Not using simbols because of #813
+export const contextsKey = 'express-validator#contexts';
 
 export interface InternalRequest extends Request {
   [contextsKey]?: ReadonlyContext[];


### PR DESCRIPTION
## Description

We change the context key from  a `string` type, which does not guarantee unicity, to a [`Symbol`](https://developer.mozilla.org/it/docs/Web/JavaScript/Reference/Global_Objects/Symbol).

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
