### PR TITLE
feat(oneOf): add new error types

### DIFF
--- a/docs/api-check.md
+++ b/docs/api-check.md
@@ -54,17 +54,22 @@ Same as `check([fields, message])`, but only checking `req.query`.
 
 > _Returns:_ an array of validation chains and `{ run: (req) => Promise<unknown[]> }`
 
-## `oneOf(validationChains[, message])`
+## `oneOf(validationChains[, options])`
 
 - `validationChains`: an array of [validation chains](api-validation-chain.md) created with `check()` or any of its variations,
   or an array of arrays containing validation chains.
-- `message` _(optional)_: an error message to use when all chains failed. Defaults to `Invalid value(s)`; see also [Dynamic Messages](feature-error-messages.md#dynamic-messages).
+- `options` _(optional)_:
+  - `message` _(optional)_: an error message to use when all chains failed. Defaults to `Invalid value(s)`; see also [Dynamic Messages](feature-error-messages.md#dynamic-messages).
+  - `errorType` _(optional)_: 
+    - `grouped` _(default)_: groups the errors according to the original validation chain groups;
+    - `flat`: joins the errors from different chain groups together;
+    - `leastErroredOnly`: returns only the errors of the least errored chain group.
 
 > _Returns:_ a middleware instance and `{ run: (req) => Promise<void> }`
 
 Creates a middleware instance that will ensure at least one of the given chains passes the validation.  
 If none of the given chains passes, an error will be pushed to the `_error` pseudo-field,
-using the given `message`, and the errors of each chain will be made available under a key `nestedErrors`.
+using the given `message`. The errors, formatted according to the `errorType` option, will be made available under the `nestedErrors` key.
 
 Example:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testRegex: 'src/.*\\.spec\\.ts',
+  testRegex: 'src/.*\\.spec\\.ts$',
   testEnvironment: 'node',
   preset: 'ts-jest',
   // TS takes precedence as we want to avoid build artifacts from being required instead of up-to-date .ts file.

--- a/src/middlewares/__snapshots__/one-of.spec.ts.snap
+++ b/src/middlewares/__snapshots__/one-of.spec.ts.snap
@@ -63,7 +63,7 @@ Array [
 ]
 `;
 
-exports[`should let the user to choose between multiple error types legacy error type 1`] = `
+exports[`should let the user to choose between multiple error types flat error type 1`] = `
 Array [
   Object {
     "msg": "Invalid value(s)",

--- a/src/middlewares/__snapshots__/one-of.spec.ts.snap
+++ b/src/middlewares/__snapshots__/one-of.spec.ts.snap
@@ -19,6 +19,29 @@ Array [
 ]
 `;
 
+exports[`should let the user to choose between multiple error types flat error type 1`] = `
+Array [
+  Object {
+    "msg": "Invalid value(s)",
+    "nestedErrors": Array [
+      Object {
+        "location": "body",
+        "msg": "Invalid value",
+        "param": "foo",
+        "value": true,
+      },
+      Object {
+        "location": "body",
+        "msg": "Invalid value",
+        "param": "bar",
+        "value": undefined,
+      },
+    ],
+    "param": "_error",
+  },
+]
+`;
+
 exports[`should let the user to choose between multiple error types grouped error type 1`] = `
 Array [
   Object {
@@ -56,29 +79,6 @@ Array [
         "msg": "Invalid value",
         "param": "foo",
         "value": true,
-      },
-    ],
-    "param": "_error",
-  },
-]
-`;
-
-exports[`should let the user to choose between multiple error types flat error type 1`] = `
-Array [
-  Object {
-    "msg": "Invalid value(s)",
-    "nestedErrors": Array [
-      Object {
-        "location": "body",
-        "msg": "Invalid value",
-        "param": "foo",
-        "value": true,
-      },
-      Object {
-        "location": "body",
-        "msg": "Invalid value",
-        "param": "bar",
-        "value": undefined,
       },
     ],
     "param": "_error",

--- a/src/middlewares/__snapshots__/one-of.spec.ts.snap
+++ b/src/middlewares/__snapshots__/one-of.spec.ts.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`error message can be the return of a function 1`] = `
+Array [
+  Object {
+    "msg": "keep trying",
+    "nestedErrors": Array [
+      Array [
+        Object {
+          "location": "body",
+          "msg": "Invalid value",
+          "param": "foo",
+          "value": true,
+        },
+      ],
+    ],
+    "param": "_error",
+  },
+]
+`;
+
+exports[`should let the user to choose between multiple error types grouped error type 1`] = `
+Array [
+  Object {
+    "msg": "Invalid value(s)",
+    "nestedErrors": Array [
+      Array [
+        Object {
+          "location": "body",
+          "msg": "Invalid value",
+          "param": "foo",
+          "value": true,
+        },
+      ],
+      Array [
+        Object {
+          "location": "body",
+          "msg": "Invalid value",
+          "param": "bar",
+          "value": undefined,
+        },
+      ],
+    ],
+    "param": "_error",
+  },
+]
+`;
+
+exports[`should let the user to choose between multiple error types leastErroredOnly error type 1`] = `
+Array [
+  Object {
+    "msg": "Invalid value(s)",
+    "nestedErrors": Array [
+      Object {
+        "location": "body",
+        "msg": "Invalid value",
+        "param": "foo",
+        "value": true,
+      },
+    ],
+    "param": "_error",
+  },
+]
+`;
+
+exports[`should let the user to choose between multiple error types legacy error type 1`] = `
+Array [
+  Object {
+    "msg": "Invalid value(s)",
+    "nestedErrors": Array [
+      Object {
+        "location": "body",
+        "msg": "Invalid value",
+        "param": "foo",
+        "value": true,
+      },
+      Object {
+        "location": "body",
+        "msg": "Invalid value",
+        "param": "bar",
+        "value": undefined,
+      },
+    ],
+    "param": "_error",
+  },
+]
+`;
+
+exports[`with a list of chain groups sets a single error for the _error key 1`] = `
+Array [
+  Object {
+    "msg": "Invalid value(s)",
+    "nestedErrors": Array [
+      Array [
+        Object {
+          "location": "cookies",
+          "msg": "Invalid value",
+          "param": "foo",
+          "value": true,
+        },
+        Object {
+          "location": "cookies",
+          "msg": "Invalid value",
+          "param": "bar",
+          "value": "def",
+        },
+      ],
+      Array [
+        Object {
+          "location": "cookies",
+          "msg": "Invalid value",
+          "param": "baz",
+          "value": 123,
+        },
+      ],
+    ],
+    "param": "_error",
+  },
+]
+`;
+
+exports[`with a list of chains sets a single error for the _error key 1`] = `
+Array [
+  Object {
+    "msg": "Invalid value(s)",
+    "nestedErrors": Array [
+      Array [
+        Object {
+          "location": "cookies",
+          "msg": "Invalid value",
+          "param": "foo",
+          "value": true,
+        },
+      ],
+      Array [
+        Object {
+          "location": "cookies",
+          "msg": "Invalid value",
+          "param": "bar",
+          "value": "def",
+        },
+      ],
+    ],
+    "param": "_error",
+  },
+]
+`;

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -140,7 +140,7 @@ describe('error message', () => {
 });
 
 describe('should let the user to choose between multiple error types', () => {
-  let errors: OneOfErrorType[] = ['grouped', 'legacy'];
+  let errors: OneOfErrorType[] = ['grouped', 'flat'];
   it.each(errors)(`%s error type`, async errorType => {
     const req: InternalRequest = {
       body: { foo: true },

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -140,23 +140,18 @@ describe('error message', () => {
 });
 
 describe('should let the user to choose between multiple error types', () => {
-  // TODO: Can't use it.each because it doesn't support done() in TypeScript
-  const errorTypes: OneOfErrorType[] = ['grouped', 'legacy'];
-  errorTypes.forEach(errorType => {
-    it(`${errorType} error type`, done => {
-      const req: InternalRequest = {
-        body: { foo: true },
-      };
-      const options: OneOfOptions = {
-        errorType,
-      };
+  let errors: OneOfErrorType[] = ['grouped', 'legacy'];
+  it.each(errors)(`%s error type`, async errorType => {
+    const req: InternalRequest = {
+      body: { foo: true },
+    };
+    const options: OneOfOptions = {
+      errorType,
+    };
 
-      oneOf([check('foo').isString(), check('bar').isFloat()], options)(req, {}, () => {
-        const context = getOneOfContext(req);
-        expect(context.errors).toMatchSnapshot();
-        done();
-      });
-    });
+    await oneOf([check('foo').isString(), check('bar').isFloat()], options).run(req);
+    const context = getOneOfContext(req);
+    expect(context.errors).toMatchSnapshot();
   });
 
   it('leastErroredOnly error type', done => {
@@ -170,7 +165,8 @@ describe('should let the user to choose between multiple error types', () => {
     oneOf(
       [
         [check('foo').isFloat(), check('bar').isInt()],
-        [check('foo').isString(), check('bar').isString()],
+        [check('foo').isString(), check('bar').isString()], // least errored
+        [check('foo').isFloat(), check('bar').isBoolean()],
       ],
       options,
     )(req, {}, () => {

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -177,6 +177,29 @@ describe('should let the user to choose between multiple error types', () => {
   });
 });
 
+describe('should default to grouped errorType', () => {
+  it('when no options are provided', async () => {
+    const req: InternalRequest = {
+      body: { foo: true },
+    };
+    await oneOf([check('foo').isString(), check('bar').isFloat()]).run(req);
+    const context = getOneOfContext(req);
+    expect(context.errors[0]?.nestedErrors?.length).toEqual(2);
+  });
+
+  it('when invalid error type is provided', async () => {
+    const req: InternalRequest = {
+      body: { foo: true },
+    };
+    await oneOf([check('foo').isString(), check('bar').isFloat()], {
+      // @ts-ignore
+      errorType: 'invalid error type',
+    }).run(req);
+    const context = getOneOfContext(req);
+    expect(context.errors[0]?.nestedErrors?.length).toEqual(2);
+  });
+});
+
 describe('imperatively run oneOf', () => {
   it('sets errors in context when validation fails', async () => {
     const req: InternalRequest = {

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -140,7 +140,7 @@ describe('error message', () => {
 });
 
 describe('should let the user to choose between multiple error types', () => {
-  let errors: OneOfErrorType[] = ['grouped', 'flat'];
+  const errors: OneOfErrorType[] = ['grouped', 'flat'];
   it.each(errors)(`%s error type`, async errorType => {
     const req: InternalRequest = {
       body: { foo: true },

--- a/src/middlewares/one-of.ts
+++ b/src/middlewares/one-of.ts
@@ -9,16 +9,19 @@ const dummyItem: ContextItem = { async run() {} };
 
 export type OneOfCustomMessageBuilder = (options: { req: Request }) => any;
 
-export type OneOfErrorType = 'grouped' | 'leastErroredOnly' | 'legacy';
-
-export interface OneOfOptions {
-  message?: OneOfCustomMessageBuilder | any;
-  errorType?: OneOfErrorType;
-}
+export type OneOfErrorType = 'grouped' | 'leastErroredOnly' | 'flat';
 
 export function oneOf(
   chains: (ValidationChain | ValidationChain[])[],
-  options: OneOfOptions = {},
+  options?: { message: OneOfCustomMessageBuilder; errorType?: OneOfErrorType },
+): Middleware & { run: (req: Request) => Promise<void> };
+export function oneOf(
+  chains: (ValidationChain | ValidationChain[])[],
+  options?: { message?: any; errorType?: OneOfErrorType },
+): Middleware & { run: (req: Request) => Promise<void> };
+export function oneOf(
+  chains: (ValidationChain | ValidationChain[])[],
+  options: { message?: any; errorType?: OneOfErrorType } = {},
 ): Middleware & { run: (req: Request) => Promise<void> } {
   options = { errorType: 'grouped', ...options };
 
@@ -63,7 +66,7 @@ export function oneOf(
             error = allErrors[leastErroredIndex];
             break;
           default:
-            // legacy
+            // flat
             error = _.flatMap(allErrors);
         }
 


### PR DESCRIPTION
## Description

This closes #956 
We allow the user to choose between different error types:
- `grouped`: new default behaviour that groups the errors based on the original branches.
- `legacy`: old behaviour that joins  the errors from different branches together
- `leastErroredOnly`: returns only the group with less errors

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
