### PR TITLE
feat: bump validator to 13.6.0

### DIFF
--- a/declarations/validator.d.ts
+++ b/declarations/validator.d.ts
@@ -81,6 +81,10 @@ declare module 'validator' {
     options?: import('../src/options').IsLatLongOptions,
   ): boolean;
   export function isLength(str: string, options: import('../src/options').MinMaxOptions): boolean;
+  export function isLicensePlate(
+    str: string,
+    options: import('../src/options').LicensePlateLocale,
+  ): boolean;
   export function isLocale(str: string): boolean;
   export function isLowercase(str: string): boolean;
   export function isMagnetURI(str: string): boolean;

--- a/declarations/validator.d.ts
+++ b/declarations/validator.d.ts
@@ -83,7 +83,7 @@ declare module 'validator' {
   export function isLength(str: string, options: import('../src/options').MinMaxOptions): boolean;
   export function isLicensePlate(
     str: string,
-    options: import('../src/options').LicensePlateLocale,
+    locale: import('../src/options').LicensePlateLocale,
   ): boolean;
   export function isLocale(str: string): boolean;
   export function isLowercase(str: string): boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14766,9 +14766,9 @@
       }
     },
     "validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "validator": "^13.5.2"
+    "validator": "^13.6.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -236,6 +236,9 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
   isLength(options: Options.MinMaxOptions) {
     return this.addStandardValidation(validator.isLength, options);
   }
+  isLicensePlate(options: Options.LicensePlateLocale) {
+    return this.addStandardValidation(validator.isLicensePlate, options);
+  }
   isLocale() {
     return this.addStandardValidation(validator.isLocale);
   }

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -236,8 +236,8 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
   isLength(options: Options.MinMaxOptions) {
     return this.addStandardValidation(validator.isLength, options);
   }
-  isLicensePlate(options: Options.LicensePlateLocale) {
-    return this.addStandardValidation(validator.isLicensePlate, options);
+  isLicensePlate(locale: Options.LicensePlateLocale) {
+    return this.addStandardValidation(validator.isLicensePlate, locale);
   }
   isLocale() {
     return this.addStandardValidation(validator.isLocale);

--- a/src/options.ts
+++ b/src/options.ts
@@ -369,6 +369,8 @@ export type PassportCountryCode =
   | 'UA'
   | 'US';
 
+export type LicensePlateLocale = 'de-DE' | 'de-LI' | 'pt-PT' | 'sq-AL' | 'pt-BR';
+
 export type TaxIDLocale = 'en-US';
 
 export type VATCountryCode = 'GB';


### PR DESCRIPTION
## Description
Updated validator to version 16.3.0 to close #1021. First time contributor here -- I've ensured the tests pass by adding the new function for `isLicensePlate` by following how other functions are added. If I missed anything let me know.

I tried to go straight to 13.6.1 but npm gave me:
```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for validator@^13.6.1.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'express-validator'
npm ERR! notarget
```

<!-- Describe what you changed and link to the relevant issue(s) -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [ ] This pull request is ready to merge.
