### PR TITLE
docs: warn users about returning `falsy` values in `.if()` with async condition

### DIFF
--- a/docs/api-validation-chain.md
+++ b/docs/api-validation-chain.md
@@ -127,6 +127,8 @@ The condition can be either:
   If it returns truthy or a promise that resolves, the validation chain will continue
   running. If it returns falsy, a promise that rejects or if it throws, the validation chain will stop.
 
+> _Note:_ async functions must return a resolved or rejected `Promise` because `truthy` or `falsy` values won't stop the chain ([#1028](https://github.com/express-validator/express-validator/issues/1028#issuecomment-830561518)).
+
 - A validation chain [created through `check()` or similar functions](api-check.md#check-field-message).
 
   If running that chain would produce errors, then the validation chain will stop.

--- a/src/context-items/custom-condition.spec.ts
+++ b/src/context-items/custom-condition.spec.ts
@@ -46,6 +46,11 @@ it('throws a validation halt if the condition is falsy', async () => {
   await expect(runItem()).rejects.toThrowError(ValidationHalt);
 });
 
+it('does not throw if a falsy value is resolved in a Promise', async () => {
+  condition.mockResolvedValue(false);
+  await expect(runItem()).resolves.toBeUndefined();
+});
+
 it('throws a validation halt if the condition is a rejected promise', async () => {
   condition.mockRejectedValue('foo');
   await expect(runItem()).rejects.toThrowError(ValidationHalt);


### PR DESCRIPTION
## Description
Closes #1028 
Changing this behaviour should be as simple as moving the await on the previous line, but would become a breaking change and I am not 100% sure if it would make sense.

<!-- Describe what you changed and link to the relevant issue(s) -->

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
