### PR TITLE
npm: correctly exclude `.ts` files when publishing with `npm@7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "src",
     "check",
     "filter",
-    "!*.spec.ts",
-    "!*.ts",
-    "*.d.ts"
+    "!**/*.spec.ts",
+    "!**/*.ts",
+    "**/*.d.ts"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Description
Closes #1034 

This PR can be tested running `npm publish --dry-run` with `npm@7` installed.


<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
