### PR TITLE
Fix schema if fields

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -15,7 +15,7 @@ export type Location = 'body' | 'cookies' | 'headers' | 'params' | 'query';
 export type Meta = { req: Request; location: Location; path: string };
 
 export type CustomValidator = (input: any, meta: Meta) => any;
-export type ConditionalValidator = (input: any, meta: Meta) => boolean;
+export type ConditionValidator = (input: any, meta: Meta) => boolean;
 export type StandardValidator = (input: string, ...options: any[]) => boolean;
 
 export type CustomSanitizer = (input: any, meta: Meta) => any;

--- a/src/base.ts
+++ b/src/base.ts
@@ -15,6 +15,7 @@ export type Location = 'body' | 'cookies' | 'headers' | 'params' | 'query';
 export type Meta = { req: Request; location: Location; path: string };
 
 export type CustomValidator = (input: any, meta: Meta) => any;
+export type ConditionFn = (input: any, meta: Meta) => boolean;
 export type StandardValidator = (input: string, ...options: any[]) => boolean;
 
 export type CustomSanitizer = (input: any, meta: Meta) => any;

--- a/src/base.ts
+++ b/src/base.ts
@@ -15,7 +15,6 @@ export type Location = 'body' | 'cookies' | 'headers' | 'params' | 'query';
 export type Meta = { req: Request; location: Location; path: string };
 
 export type CustomValidator = (input: any, meta: Meta) => any;
-export type ConditionValidator = (input: any, meta: Meta) => boolean;
 export type StandardValidator = (input: string, ...options: any[]) => boolean;
 
 export type CustomSanitizer = (input: any, meta: Meta) => any;

--- a/src/base.ts
+++ b/src/base.ts
@@ -15,6 +15,7 @@ export type Location = 'body' | 'cookies' | 'headers' | 'params' | 'query';
 export type Meta = { req: Request; location: Location; path: string };
 
 export type CustomValidator = (input: any, meta: Meta) => any;
+export type ConditionalValidator = (input: any, meta: Meta) => boolean;
 export type StandardValidator = (input: string, ...options: any[]) => boolean;
 
 export type CustomSanitizer = (input: any, meta: Meta) => any;

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -1,5 +1,5 @@
 import * as validator from 'validator';
-import { CustomValidator, StandardValidator } from '../base';
+import { ConditionFn, CustomValidator, StandardValidator } from '../base';
 import { CustomValidation, StandardValidation } from '../context-items';
 import { ContextBuilder } from '../context-builder';
 import * as Options from '../options';
@@ -25,6 +25,19 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     this.negateNext = true;
     return this.chain;
   }
+
+  // TODO: add if functionality here, requires refactor of negateNext?
+  // if(conditionFn: ConditionFn) {
+  //   if (conditionFn(value)) { // how to pass meta here?
+  //     this.negateAll = true; // or new property?
+  //   } else {
+  //     return this.chain
+  //   }
+  // }
+  if(_: ConditionFn) { // attempt to allow test to run
+    return this.chain;
+  }
+
 
   withMessage(message: any) {
     this.lastValidator.message = message;

--- a/src/chain/validators.ts
+++ b/src/chain/validators.ts
@@ -1,4 +1,4 @@
-import { CustomValidator, DynamicMessageCreator, ConditionValidator } from '../base';
+import { CustomValidator, DynamicMessageCreator } from '../base';
 import * as Options from '../options';
 
 export interface Validators<Return> {
@@ -9,7 +9,6 @@ export interface Validators<Return> {
 
   // custom validators
   custom(validator: CustomValidator): Return;
-  if(condition: ConditionValidator): Return;
   exists(options?: { checkFalsy?: boolean; checkNull?: boolean }): Return;
   isArray(options?: { min?: number; max?: number }): Return;
   isObject(options?: { strict?: boolean }): Return;

--- a/src/chain/validators.ts
+++ b/src/chain/validators.ts
@@ -1,4 +1,4 @@
-import { CustomValidator, DynamicMessageCreator } from '../base';
+import { CustomValidator, DynamicMessageCreator, StandardValidator } from '../base';
 import * as Options from '../options';
 
 export interface Validators<Return> {
@@ -9,6 +9,7 @@ export interface Validators<Return> {
 
   // custom validators
   custom(validator: CustomValidator): Return;
+  if(condition: StandardValidator): Return;
   exists(options?: { checkFalsy?: boolean; checkNull?: boolean }): Return;
   isArray(options?: { min?: number; max?: number }): Return;
   isObject(options?: { strict?: boolean }): Return;

--- a/src/chain/validators.ts
+++ b/src/chain/validators.ts
@@ -1,4 +1,4 @@
-import { CustomValidator, DynamicMessageCreator, StandardValidator } from '../base';
+import { CustomValidator, DynamicMessageCreator, ConditionValidator } from '../base';
 import * as Options from '../options';
 
 export interface Validators<Return> {
@@ -9,7 +9,7 @@ export interface Validators<Return> {
 
   // custom validators
   custom(validator: CustomValidator): Return;
-  if(condition: StandardValidator): Return;
+  if(condition: ConditionValidator): Return;
   exists(options?: { checkFalsy?: boolean; checkNull?: boolean }): Return;
   isArray(options?: { min?: number; max?: number }): Return;
   isObject(options?: { strict?: boolean }): Return;

--- a/src/chain/validators.ts
+++ b/src/chain/validators.ts
@@ -1,4 +1,4 @@
-import { CustomValidator, DynamicMessageCreator } from '../base';
+import { CustomValidator, DynamicMessageCreator, ConditionFn } from '../base';
 import * as Options from '../options';
 
 export interface Validators<Return> {
@@ -10,6 +10,7 @@ export interface Validators<Return> {
   // custom validators
   custom(validator: CustomValidator): Return;
   exists(options?: { checkFalsy?: boolean; checkNull?: boolean }): Return;
+  if(conditionFn: ConditionFn): Return;
   isArray(options?: { min?: number; max?: number }): Return;
   isObject(options?: { strict?: boolean }): Return;
   isString(): Return;

--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -112,28 +112,25 @@ describe('on each field', () => {
       expect.objectContaining({ path: 'bar', value: 'a', originalValue: 'baz' }),
     );
   });
-  
-  it('halts validation if `if` statement is falsy', async () => {
+
+  it('halts chain execution if "if" statement resolves to false', async () => {
     const schema = checkSchema({
       foo: {
-        if: {
-          condition: (value, _) => {
-            return value;
-          }
+        if: (value) => {
+          return value !== ""
         },
-        notEmpty: true // will cause error if `if` condition does not halt execution
-    });
-    
-    const results = await Promise.all(
-      schema.map(chain =>
-        chain.run({
-          query: { foo: '' },
-        }),
-      ),
-    );
-    
-    expect(results[0].context.errors).toHaveLength(0);
-  }
+        isEmpty: true
+      }
+    })
+
+    const result = await Promise.all(
+      schema.map(chain => chain.run({
+        query: { foo: "" }
+      }))
+    )
+
+    expect(result).toHaveLength(0);
+  })
 
   it('sets error message', () => {
     const chain = checkSchema({

--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -112,6 +112,28 @@ describe('on each field', () => {
       expect.objectContaining({ path: 'bar', value: 'a', originalValue: 'baz' }),
     );
   });
+  
+  it('halts validation if `if` statement is falsy', async () => {
+    const schema = checkSchema({
+      foo: {
+        if: {
+          condition: (value, _) => {
+            return value;
+          }
+        },
+        notEmpty: true // will cause error if `if` condition does not halt execution
+    });
+    
+    const results = await Promise.all(
+      schema.map(chain =>
+        chain.run({
+          query: { foo: '' },
+        }),
+      ),
+    );
+    
+    expect(results[0].context.errors).toHaveLength(0);
+  }
 
   it('sets error message', () => {
     const chain = checkSchema({

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -1,6 +1,6 @@
 import { Sanitizers } from '../chain/sanitizers';
 import { Validators } from '../chain/validators';
-import { DynamicMessageCreator, Location, Request } from '../base';
+import { ConditionFn, DynamicMessageCreator, Location, Request } from '../base';
 import { ValidationChain, ValidatorsImpl } from '../chain';
 import { Optional } from '../context';
 import { check } from './check';
@@ -12,7 +12,8 @@ type ValidatorSchemaOptions<K extends keyof Validators<any>> =
       errorMessage?: DynamicMessageCreator | any;
       negated?: boolean;
       bail?: boolean;
-    };
+    }
+    | ConditionFn;
 
 export type ValidatorsSchema = { [K in keyof Validators<any>]?: ValidatorSchemaOptions<K> };
 
@@ -82,6 +83,10 @@ export function checkSchema(
 
         // Using "!" because typescript doesn't know it isn't undefined.
         const methodCfg = config[method]!;
+
+        if (method === "if") {
+          return methodCfg ? chain : null;
+        }
         
         let options: any[] = methodCfg === true ? [] : methodCfg.options || [];
         if (options != null && !Array.isArray(options)) {

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -82,8 +82,9 @@ export function checkSchema(
 
         // Using "!" because typescript doesn't know it isn't undefined.
         const methodCfg = config[method]!;
-
-        let options: any[] = methodCfg === true ? [] : methodCfg.options || [];
+        
+        const field = method === 'if' ? 'condition' : 'options';
+        let options: any[] = methodCfg === true ? [] : methodCfg[field] || [];
         if (options != null && !Array.isArray(options)) {
           options = [options];
         }

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -83,8 +83,7 @@ export function checkSchema(
         // Using "!" because typescript doesn't know it isn't undefined.
         const methodCfg = config[method]!;
         
-        const field = method === 'if' ? 'condition' : 'options';
-        let options: any[] = methodCfg === true ? [] : methodCfg[field] || [];
+        let options: any[] = methodCfg === true ? [] : methodCfg.options || [];
         if (options != null && !Array.isArray(options)) {
           options = [options];
         }


### PR DESCRIPTION
## Description

Closes #834
In the [documentation](https://express-validator.github.io/docs/validation-chain-api.html#ifcondition), `.if(condition)` takes a property `condition`. Using schema validation however, the script only looks for `options` properties. The resulting discrepancy between schema validation and the validation chain API is confusing. In general I think schema validation is under documented, as most validation chain functions do not work as documented using schema validation.

Nevertheless, the above PR brings schema validation closer to the state of the docs. I had to create an if statement as well, seeing as you guys likely don't want every field to allow both the use of `options` and `condition`.

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [ ] This pull request is ready to merge.
