### PR TITLE
fix: prioritize `withMessage` errors over the ones thrown by `CustomValidator`

### DIFF
--- a/docs/feature-error-messages.md
+++ b/docs/feature-error-messages.md
@@ -65,6 +65,13 @@ app.post(
 );
 ```
 
+You may still use the [`.withMessage()` method](api-validation-chain.md#withmessagemessage) to
+override any message obtained from the custom validator with a custom message that is more appropriate
+to the route's context.
+
+This is especially useful if you wish to reuse a custom validator function across several routes
+throughout the application.
+
 ### Field Level
 
 Messages can be specified at the field level by using the second parameter of the

--- a/src/context-items/custom-validation.ts
+++ b/src/context-items/custom-validation.ts
@@ -24,7 +24,7 @@ export class CustomValidation implements ContextItem {
         return;
       }
 
-      context.addError((err instanceof Error ? err.message : err) || this.message, value, meta);
+      context.addError(this.message || (err instanceof Error ? err.message : err), value, meta);
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #1047.
- Adjusted tests to account for set validation messages overriding thrown errors.
  - They were split into two `describe` blocks, one with and one without a message set.
- Adjusted `src/context-items/custom-validation.ts` to favor the set message over the thrown message.
- Tweaks "Custom Validator Level" section of `docs/feature-error-messages.md` to clarify this overriding behavior.

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
