### PR TITLE
fix: add type for `checkSchema` function return

### DIFF
--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -3,8 +3,8 @@ import { Validators } from '../chain/validators';
 import { DynamicMessageCreator, Location, Request } from '../base';
 import { ValidationChain, ValidatorsImpl } from '../chain';
 import { Optional, ReadonlyContext } from '../context';
-import { check } from './check';
 import { Result } from '../validation-result';
+import { check } from './check';
 
 type ValidatorSchemaOptions<K extends keyof Validators<any>> =
   | true

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -2,8 +2,9 @@ import { Sanitizers } from '../chain/sanitizers';
 import { Validators } from '../chain/validators';
 import { DynamicMessageCreator, Location, Request } from '../base';
 import { ValidationChain, ValidatorsImpl } from '../chain';
-import { Optional } from '../context';
+import { Optional, ReadonlyContext } from '../context';
 import { check } from './check';
+import { Result } from '../validation-result';
 
 type ValidatorSchemaOptions<K extends keyof Validators<any>> =
   | true
@@ -62,7 +63,7 @@ export function checkSchema(
   schema: Schema,
   defaultLocations: Location[] = validLocations,
 ): ValidationChain[] & {
-  run: (req: Request) => Promise<unknown[]>;
+  run: (req: Request) => Promise<(Result & { context: ReadonlyContext })[]>;
 } {
   const chains = Object.keys(schema).map(field => {
     const config = schema[field];

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -2,6 +2,7 @@ import { Sanitizers } from '../chain/sanitizers';
 import { Validators } from '../chain/validators';
 import { DynamicMessageCreator, Location, Request } from '../base';
 import { ValidationChain, ValidatorsImpl } from '../chain';
+import { Optional } from '../context';
 import { ResultWithContext } from '../chain/context-runner-impl';
 import { check } from './check';
 

--- a/src/middlewares/schema.ts
+++ b/src/middlewares/schema.ts
@@ -2,8 +2,7 @@ import { Sanitizers } from '../chain/sanitizers';
 import { Validators } from '../chain/validators';
 import { DynamicMessageCreator, Location, Request } from '../base';
 import { ValidationChain, ValidatorsImpl } from '../chain';
-import { Optional, ReadonlyContext } from '../context';
-import { Result } from '../validation-result';
+import { ResultWithContext } from '../chain/context-runner-impl';
 import { check } from './check';
 
 type ValidatorSchemaOptions<K extends keyof Validators<any>> =
@@ -63,7 +62,7 @@ export function checkSchema(
   schema: Schema,
   defaultLocations: Location[] = validLocations,
 ): ValidationChain[] & {
-  run: (req: Request) => Promise<(Result & { context: ReadonlyContext })[]>;
+  run: (req: Request) => Promise<ResultWithContext[]>;
 } {
   const chains = Object.keys(schema).map(field => {
     const config = schema[field];


### PR DESCRIPTION
## Background

![image](https://user-images.githubusercontent.com/10917606/127730213-5c313ef6-ae1d-482a-af15-9c2027ac3aa6.png)
When getting a list of result by calling `checkSchema().run`, I was unable to use those handy methods on result as it was marked as `unknown` currently. 
Would be def great if we could add type support for the return of `checkSchema`, thanks.

## Description

Type definition for `checkSchema` function return.

## To-do list

- [x] I have added tests for what I changed.

- [x] This pull request is ready to merge.
