### PR TITLE
schema usage according to documentation results in Error

### DIFF
--- a/docs/feature-schema-validation.md
+++ b/docs/feature-schema-validation.md
@@ -72,7 +72,9 @@ app.put(
     'addresses.*.postalCode': {
       // Make this field optional when undefined or null
       optional: { options: { nullable: true } },
-      isPostalCode: true,
+      isPostalCode: {
+        options: 'US', // set postalCode locale here
+      },
     },
   }),
   (req, res, next) => {


### PR DESCRIPTION
Current schema validation usage according to [the feature example](https://express-validator.github.io/docs/schema-validation.html) of `isPostalCode` results in an error: 

```json
    "errors": {
        "message": "Invalid locale 'undefined'"
    }
```

According to #1085, a PR for v7 is on the way to improve this (?). Anyway, I'd appreciate it if you could update this in the documentation of v6 as well. Do tell me if I should PR to a different branch (`v6.13-features` maybe?) instead.

- [x] This pull request is ready to merge.