### PR TITLE
Add `validationResult()` for schema validation example

### DIFF
--- a/docs/feature-schema-validation.md
+++ b/docs/feature-schema-validation.md
@@ -10,7 +10,7 @@ the error messages, locations and validations/sanitizations.
 Its syntax looks like this:
 
 ```js
-const { checkSchema } = require('express-validator');
+const { checkSchema, validationResult } = require('express-validator');
 app.put(
   '/user/:id/password',
   checkSchema({
@@ -86,6 +86,10 @@ app.put(
     },
   }),
   (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
     // handle the request as usual
   },
 );


### PR DESCRIPTION
## Description

Missing `validationResult()` usage could make someone hard to use express-validator with Schema Validation at the beginning so it would be better to add little more codes.

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed. => No need to test, it is just fixing document exmaple.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
