### PR TITLE
docs: remove dependencies status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![npm version](https://img.shields.io/npm/v/express-validator.svg)](https://www.npmjs.com/package/express-validator)
 [![Build Status](https://img.shields.io/travis/express-validator/express-validator.svg)](http://travis-ci.org/express-validator/express-validator)
-[![Dependency Status](https://img.shields.io/david/express-validator/express-validator.svg)](https://david-dm.org/express-validator/express-validator)
 [![Coverage Status](https://img.shields.io/coveralls/express-validator/express-validator.svg)](https://coveralls.io/github/express-validator/express-validator?branch=master)
 
 An [express.js](https://github.com/visionmedia/express) middleware for


### PR DESCRIPTION
Apparently https://david-dm.org is no more, so I'm removing the badge.