### PR TITLE
fix: correctly run `.matches` when passing regex object

### DIFF
--- a/src/chain/validators-impl.spec.ts
+++ b/src/chain/validators-impl.spec.ts
@@ -363,3 +363,19 @@ describe('#notEmpty()', () => {
     );
   });
 });
+
+describe('correctly merges validator.matches flags', () => {
+  it('correctly uses modifiers and string', () => {
+    validators.matches('baz', 'gi');
+    expect(builder.addItem).toHaveBeenCalledWith(
+      new StandardValidation(validator.matches, false, ['baz', 'gi']),
+    );
+  });
+
+  it('correctly uses modifiers and regex flags', () => {
+    validators.matches(/baz/gi, 'm');
+    expect(builder.addItem).toHaveBeenCalledWith(
+      new StandardValidation(validator.matches, false, ['baz', "mgi"]),
+    );
+  });
+});

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -337,7 +337,7 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
       validator.matches,
       ...(typeof pattern === 'string'
         ? [pattern, modifiers]
-        : [pattern.source, ...[new Set((modifiers || '') + pattern.flags)].join('')]),
+        : [pattern.source, [...new Set((modifiers || '') + pattern.flags)].join('')]),
     ]);
   }
 }

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -333,8 +333,7 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     return this.addStandardValidation(validator.isWhitelisted, chars);
   }
   matches(pattern: RegExp | string, modifiers?: string) {
-    return this.addStandardValidation.apply([
-      this,
+    return this.addStandardValidation.apply(this, [
       validator.matches,
       ...(typeof pattern === 'string'
         ? [pattern, modifiers]

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -334,7 +334,7 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
   }
   matches(pattern: RegExp | string, modifiers?: string) {
     return this.addStandardValidation.apply([
-      null,
+      this,
       validator.matches,
       ...(typeof pattern === 'string'
         ? [pattern, modifiers]

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -333,10 +333,12 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     return this.addStandardValidation(validator.isWhitelisted, chars);
   }
   matches(pattern: RegExp | string, modifiers?: string) {
-    return this.addStandardValidation(
+    return this.addStandardValidation.apply([
+      null,
       validator.matches,
-      typeof pattern === 'string' ? pattern : pattern.source,
-      modifiers,
-    );
+      ...(typeof pattern === 'string'
+        ? [pattern, modifiers]
+        : [pattern.source, ...[new Set((modifiers || '') + pattern.flags)].join('')]),
+    ]);
   }
 }

--- a/src/chain/validators-impl.ts
+++ b/src/chain/validators-impl.ts
@@ -333,6 +333,10 @@ export class ValidatorsImpl<Chain> implements Validators<Chain> {
     return this.addStandardValidation(validator.isWhitelisted, chars);
   }
   matches(pattern: RegExp | string, modifiers?: string) {
-    return this.addStandardValidation(validator.matches, pattern, modifiers);
+    return this.addStandardValidation(
+      validator.matches,
+      typeof pattern === 'string' ? pattern : pattern.source,
+      modifiers,
+    );
   }
 }


### PR DESCRIPTION
Forcing pattern to be string, to cope with lib validator which doesn't reset the RegExp instance
Fixes #1127 

## Description

Fixes matches validation failing one other time, passing regex value with g flag.

- [ ] I have added tests for what I changed.

I didn't add any tests, because it works exactly as before, but simply extracts the source when passing the regex.

- [x] This pull request is ready to merge.
