### PR TITLE
Correctly return nullable data in `matchedData`

### DIFF
--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -123,7 +123,7 @@ describe('#getData()', () => {
     context = new ContextBuilder().setOptional({ checkFalsy: false, nullable: true }).build();
     context.addFieldInstances(data);
 
-    expect(context.getData({ requiredOnly: true })).toEqual([]);
+    expect(context.getData({ requiredOnly: true })).toEqual([data[0]]);
   });
 
   it('filters out falsies when context optional with checkFalsy = true', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -32,7 +32,7 @@ export class Context {
       options.requiredOnly && optional
         ? [
             (value: any) => value !== undefined,
-            (value: any) => (optional.nullable ? value != null : true),
+            (value: any) => (optional.nullable ? true : value !== null),
             (value: any) => (optional.checkFalsy ? value : true),
           ]
         : [];

--- a/src/matched-data.spec.ts
+++ b/src/matched-data.spec.ts
@@ -38,6 +38,22 @@ it('includes data that was validated with wildcards', done => {
   });
 });
 
+it('includes nullable optional', done => {
+  const req = {
+    headers: { foo: [1, 2, 3] },
+    query: { bar: null },
+  };
+
+  check(['foo.*', 'bar']).optional({ nullable: true }).isInt()(req, {}, () => {
+    expect(matchedData(req)).toEqual({
+      foo: [1, 2, 3],
+      bar: null,
+    });
+
+    done();
+  });
+});
+
 it('does not include valid data from invalid oneOf() chain group', done => {
   const req = {
     query: { foo: 'foo', bar: 123, baz: 'baz' },

--- a/src/matched-data.spec.ts
+++ b/src/matched-data.spec.ts
@@ -8,7 +8,7 @@ it('works if no validation or sanitization chains ran', () => {
 
 it('includes only valid, non-optional data by default', done => {
   const req = {
-    headers: { foo: 'bla', bar: '123' },
+    headers: { foo: 'bla', bar: '123', baz: null },
   };
 
   const middleware = check(['foo', 'bar', 'baz']).optional().isInt();
@@ -16,6 +16,23 @@ it('includes only valid, non-optional data by default', done => {
   middleware(req, {}, () => {
     expect(matchedData(req)).toEqual({
       bar: '123',
+    });
+
+    done();
+  });
+});
+
+it('includes only valid, including nullable data by default', done => {
+  const req = {
+    headers: { foo: 'bla', bar: '123', baz: null },
+  };
+
+  const middleware = check(['foo', 'bar', 'baz']).optional({ nullable: true }).isInt();
+
+  middleware(req, {}, () => {
+    expect(matchedData(req)).toEqual({
+      bar: '123',
+      baz: null,
     });
 
     done();

--- a/src/matched-data.ts
+++ b/src/matched-data.ts
@@ -45,9 +45,10 @@ function createValidityFilter(onlyValidData = true) {
     : (field: FieldInstanceBag) => {
         const hasError = field.context.errors.some(
           error =>
-            error.location === field.instance.location && error.param === field.instance.path,
+            error.location === field.instance.location &&
+            error.param === field.instance.path &&
+            field.instance.value !== null,
         );
-
         return !hasError;
       };
 }


### PR DESCRIPTION
## Description

Correctly return nullable data in `matchedData`:

https://github.com/express-validator/express-validator/issues/1048

## To-do list

- [x] I have added tests for what I changed.
- [x] This pull request is ready to merge.
