### PR TITLE
docs: update sanitization chain

### DIFF
--- a/docs/api-sanitization-chain.md
+++ b/docs/api-sanitization-chain.md
@@ -112,7 +112,7 @@ Converts the value to an array. `undefined` will result in an empty array.
 
 ```js
 app.post('/', [body('checkboxes').toArray()], (req, res, next) => {
-  // ['foo', 'bar]  => ['foo', 'bar']
+  // ['foo', 'bar']  => ['foo', 'bar']
   // 'foo'          => ['foo']
   // undefined      => []
   console.log(req.body.checkboxes);


### PR DESCRIPTION
fixed typo in line 115, changed 'bar to 'bar'
