### PR TITLE
Change signature of Context#addError()

### DIFF
--- a/src/chain/context-runner-impl.spec.ts
+++ b/src/chain/context-runner-impl.spec.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 it('returns Result for current context', async () => {
   builder.addItem({
     async run(context, value, meta) {
-      context.addError('some error', value, meta);
+      context.addError({ type: 'single', value, meta });
     },
   });
   const result = await contextRunner.run({});

--- a/src/context-items/bail.spec.ts
+++ b/src/context-items/bail.spec.ts
@@ -9,10 +9,15 @@ it('does not throw if the context has no errors', () => {
 
 it('throws a validation halt if the context has errors', () => {
   const context = new ContextBuilder().build();
-  context.addError('foo', 'value', {
-    req: {},
-    location: 'body',
-    path: 'bar',
+  context.addError({
+    type: 'single',
+    message: 'foo',
+    value: 'value',
+    meta: {
+      req: {},
+      location: 'body',
+      path: 'bar',
+    },
   });
 
   expect(() => new Bail().run(context)).toThrowError(ValidationHalt);

--- a/src/context-items/custom-validation.spec.ts
+++ b/src/context-items/custom-validation.spec.ts
@@ -25,7 +25,12 @@ const createSyncTest = (options: { returnValue: any; addsError: boolean }) => as
   validator.mockReturnValue(options.returnValue);
   await validation.run(context, 'bar', meta);
   if (options.addsError) {
-    expect(context.addError).toHaveBeenCalledWith(validation.message, 'bar', meta);
+    expect(context.addError).toHaveBeenCalledWith({
+      type: 'single',
+      message: validation.message,
+      value: 'bar',
+      meta,
+    });
   } else {
     expect(context.addError).not.toHaveBeenCalled();
   }
@@ -53,13 +58,23 @@ describe('when not negated', () => {
         throw new Error('boom');
       });
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith({
+        type: 'single',
+        message: 'nope',
+        value: 'bar',
+        meta,
+      });
     });
 
     it('adds error with validation message if validator returns a promise that rejects', async () => {
       validator.mockRejectedValue('a bomb');
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith({
+        type: 'single',
+        message: 'nope',
+        value: 'bar',
+        meta,
+      });
     });
   });
 
@@ -73,13 +88,23 @@ describe('when not negated', () => {
         throw new Error('boom');
       });
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('boom', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith({
+        type: 'single',
+        message: 'boom',
+        value: 'bar',
+        meta,
+      });
     });
 
     it('adds error with rejection message if validator returns a promise that rejects', async () => {
       validator.mockRejectedValue('a bomb');
       await validation.run(context, 'bar', meta);
-      expect(context.addError).toHaveBeenCalledWith('a bomb', 'bar', meta);
+      expect(context.addError).toHaveBeenCalledWith({
+        type: 'single',
+        message: 'a bomb',
+        value: 'bar',
+        meta,
+      });
     });
   });
 
@@ -123,6 +148,11 @@ describe('when negated', () => {
   it('adds error with validation message if validator returns a promise that resolves', async () => {
     validator.mockResolvedValue(true);
     await validation.run(context, 'bar', meta);
-    expect(context.addError).toHaveBeenCalledWith('nope', 'bar', meta);
+    expect(context.addError).toHaveBeenCalledWith({
+      type: 'single',
+      message: 'nope',
+      value: 'bar',
+      meta,
+    });
   });
 });

--- a/src/context-items/custom-validation.ts
+++ b/src/context-items/custom-validation.ts
@@ -17,14 +17,19 @@ export class CustomValidation implements ContextItem {
       // A promise that was resolved only adds an error if negated.
       // Otherwise it always suceeds
       if ((!isPromise && failed) || (isPromise && this.negated)) {
-        context.addError(this.message, value, meta);
+        context.addError({ type: 'single', message: this.message, value, meta });
       }
     } catch (err) {
       if (this.negated) {
         return;
       }
 
-      context.addError(this.message || (err instanceof Error ? err.message : err), value, meta);
+      context.addError({
+        type: 'single',
+        message: this.message || (err instanceof Error ? err.message : err),
+        value,
+        meta,
+      });
     }
   }
 }

--- a/src/context-items/standard-validation.spec.ts
+++ b/src/context-items/standard-validation.spec.ts
@@ -27,7 +27,12 @@ const createTest = (options: { returnValue: any; addsError: boolean }) => async 
   validator.mockReturnValue(options.returnValue);
   await validation.run(context, 'bar', meta);
   if (options.addsError) {
-    expect(context.addError).toHaveBeenCalledWith(validation.message, 'bar', meta);
+    expect(context.addError).toHaveBeenCalledWith({
+      type: 'single',
+      message: validation.message,
+      value: 'bar',
+      meta,
+    });
   } else {
     expect(context.addError).not.toHaveBeenCalled();
   }

--- a/src/context-items/standard-validation.ts
+++ b/src/context-items/standard-validation.ts
@@ -20,7 +20,7 @@ export class StandardValidation implements ContextItem {
     values.forEach(value => {
       const result = this.validator(this.stringify(value), ...this.options);
       if (this.negated ? result : !result) {
-        context.addError(this.message, value, meta);
+        context.addError({ type: 'single', message: this.message, value, meta });
       }
     });
   }

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -1,6 +1,6 @@
 import { Context } from './context';
 import { ContextBuilder } from './context-builder';
-import { FieldInstance, Meta } from './base';
+import { FieldInstance, Meta, ValidationError } from './base';
 
 let context: Context;
 let data: FieldInstance[];
@@ -32,55 +32,106 @@ describe('#addError()', () => {
     req: {},
   };
 
-  it('pushes an error with default error message', () => {
-    context.addError({ type: 'single', value: 'foo', meta });
+  describe('for type single', () => {
+    it('pushes an error with default error message', () => {
+      context.addError({ type: 'single', value: 'foo', meta });
 
-    expect(context.errors).toHaveLength(1);
-    expect(context.errors).toContainEqual({
-      value: 'foo',
-      msg: 'Invalid value',
-      param: 'bar',
-      location: 'headers',
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors).toContainEqual({
+        value: 'foo',
+        msg: 'Invalid value',
+        param: 'bar',
+        location: 'headers',
+      });
+    });
+
+    it('pushes an error with context message', () => {
+      context = new ContextBuilder().setMessage('context message').build();
+      context.addError({ type: 'single', value: 'foo', meta });
+
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors).toContainEqual({
+        value: 'foo',
+        msg: 'context message',
+        param: 'bar',
+        location: 'headers',
+      });
+    });
+
+    it('pushes an error with argument message', () => {
+      context.addError({ type: 'single', message: 'oh noes', value: 'foo', meta });
+
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors).toContainEqual({
+        value: 'foo',
+        msg: 'oh noes',
+        param: 'bar',
+        location: 'headers',
+      });
+    });
+
+    it('pushes an error with the message function return ', () => {
+      const message = jest.fn(() => 123);
+      context.addError({ type: 'single', message, value: 'foo', meta });
+
+      expect(message).toHaveBeenCalledWith('foo', meta);
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors).toContainEqual({
+        value: 'foo',
+        msg: 123,
+        param: 'bar',
+        location: 'headers',
+      });
     });
   });
 
-  it('pushes an error with context message', () => {
-    context = new ContextBuilder().setMessage('context message').build();
-    context.addError({ type: 'single', value: 'foo', meta });
-
-    expect(context.errors).toHaveLength(1);
-    expect(context.errors).toContainEqual({
+  describe('for type nested', () => {
+    const nestedError: ValidationError = {
       value: 'foo',
-      msg: 'context message',
       param: 'bar',
-      location: 'headers',
+      location: 'body',
+      msg: 'Oh no',
+    };
+
+    it('pushes an error for the _error param with nested errors', () => {
+      context.addError({
+        type: 'nested',
+        nestedErrors: [nestedError],
+      });
+
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors[0].param).toBe('_error');
+      expect(context.errors[0].nestedErrors).toEqual([nestedError]);
+    });
+
+    it('pushes an error with default error message', () => {
+      context.addError({
+        type: 'nested',
+        nestedErrors: [nestedError],
+      });
+
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors[0].msg).toBe('Invalid value');
+    });
+
+    it('pushes an error with argument message', () => {
+      context.addError({
+        type: 'nested',
+        message: 'oh noes',
+        nestedErrors: [nestedError],
+      });
+
+      expect(context.errors).toHaveLength(1);
+      expect(context.errors[0].msg).toBe('oh noes');
     });
   });
 
-  it('pushes an error with argument message', () => {
-    context.addError({ type: 'single', message: 'oh noes', value: 'foo', meta });
-
-    expect(context.errors).toHaveLength(1);
-    expect(context.errors).toContainEqual({
-      value: 'foo',
-      msg: 'oh noes',
-      param: 'bar',
-      location: 'headers',
-    });
-  });
-
-  it('pushes an error with the message function return ', () => {
-    const message = jest.fn(() => 123);
-    context.addError({ type: 'single', message, value: 'foo', meta });
-
-    expect(message).toHaveBeenCalledWith('foo', meta);
-    expect(context.errors).toHaveLength(1);
-    expect(context.errors).toContainEqual({
-      value: 'foo',
-      msg: 123,
-      param: 'bar',
-      location: 'headers',
-    });
+  it('throws if the error type is incorrect', () => {
+    // The ts-expect-error below adds a static guarantee that we're indeed using a type that isn't
+    // specified in the addError signature.
+    // @ts-expect-error
+    const fn = () => context.addError({ type: 'foo' });
+    expect(fn).toThrow();
   });
 });
 

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -26,12 +26,14 @@ beforeEach(() => {
 });
 
 describe('#addError()', () => {
+  const meta: Meta = {
+    path: 'bar',
+    location: 'headers',
+    req: {},
+  };
+
   it('pushes an error with default error message', () => {
-    context.addError(null, 'foo', {
-      path: 'bar',
-      location: 'headers',
-      req: {},
-    });
+    context.addError({ type: 'single', value: 'foo', meta });
 
     expect(context.errors).toHaveLength(1);
     expect(context.errors).toContainEqual({
@@ -44,11 +46,7 @@ describe('#addError()', () => {
 
   it('pushes an error with context message', () => {
     context = new ContextBuilder().setMessage('context message').build();
-    context.addError(null, 'foo', {
-      path: 'bar',
-      location: 'headers',
-      req: {},
-    });
+    context.addError({ type: 'single', value: 'foo', meta });
 
     expect(context.errors).toHaveLength(1);
     expect(context.errors).toContainEqual({
@@ -60,11 +58,7 @@ describe('#addError()', () => {
   });
 
   it('pushes an error with argument message', () => {
-    context.addError('oh noes', 'foo', {
-      path: 'bar',
-      location: 'headers',
-      req: {},
-    });
+    context.addError({ type: 'single', message: 'oh noes', value: 'foo', meta });
 
     expect(context.errors).toHaveLength(1);
     expect(context.errors).toContainEqual({
@@ -76,13 +70,8 @@ describe('#addError()', () => {
   });
 
   it('pushes an error with the message function return ', () => {
-    const meta: Meta = {
-      path: 'bar',
-      location: 'headers',
-      req: {},
-    };
     const message = jest.fn(() => 123);
-    context.addError(message, 'foo', meta);
+    context.addError({ type: 'single', message, value: 'foo', meta });
 
     expect(message).toHaveBeenCalledWith('foo', meta);
     expect(context.errors).toHaveLength(1);

--- a/src/middlewares/one-of.ts
+++ b/src/middlewares/one-of.ts
@@ -108,12 +108,14 @@ export function oneOf(
         }
 
         // Only add an error to the context if no group of chains had success.
-        surrogateContext.addError(
-          typeof options.message === 'function'
-            ? options.message({ req })
-            : options.message || 'Invalid value(s)',
-          error,
-        );
+        surrogateContext.addError({
+          type: 'nested',
+          message:
+            typeof options.message === 'function'
+              ? options.message({ req })
+              : options.message || 'Invalid value(s)',
+          nestedErrors: error,
+        });
       }
 
       // Final context running pass to ensure contexts are added and values are modified properly


### PR DESCRIPTION
## Description

I'm changing the signature of `Context#addError()` because using method overloads was a mistake 😛 
Discriminated unions work much better as the intent becomes clear for the consumer code.

Furthermore, I'm planning on adding yet another style of error for v7, so the overloads would become even more confusing going forward...

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
