### PR TITLE
Add ExpressValidator class

### DIFF
--- a/src/express-validator.spec.ts
+++ b/src/express-validator.spec.ts
@@ -57,6 +57,17 @@ describe('ExpressValidator', () => {
     });
   });
 
+  describe('#checkExact()', () => {
+    it('works with custom chains', async () => {
+      const req = { query: { foo: 1 } };
+      const { query, checkExact } = createInstance();
+      const result = await checkExact(query('bar').isAllowedDomain()).run(req);
+      const errors = result.mapped();
+      expect(isAllowedDomain).toHaveBeenCalled();
+      expect(errors._unknown_fields).toBeDefined();
+    });
+  });
+
   describe('#checkSchema()', () => {
     it('creates a schema with the extension methods', async () => {
       const { checkSchema } = createInstance();

--- a/src/express-validator.spec.ts
+++ b/src/express-validator.spec.ts
@@ -1,0 +1,87 @@
+import {
+  CustomSanitizer,
+  CustomValidator,
+  FieldValidationError,
+  Meta,
+  ValidationError,
+} from './base';
+import { ExpressValidator } from './express-validator';
+
+describe('ExpressValidator', () => {
+  let isAllowedDomain: CustomValidator;
+  let removeEmailAttribute: CustomSanitizer;
+  const createInstance = () => new ExpressValidator({ isAllowedDomain }, { removeEmailAttribute });
+
+  beforeEach(() => {
+    isAllowedDomain = jest.fn(() => true);
+    removeEmailAttribute = jest.fn(value => value);
+  });
+
+  describe.each([
+    ['check', ['body', 'cookies', 'headers', 'params', 'query']],
+    ['body', ['body']],
+    ['cookies', ['cookies']],
+    ['headers', ['headers']],
+    ['params', ['params']],
+    ['query', ['query']],
+  ] as const)('#%s()', (method, locations) => {
+    const foo = 'bar';
+    const req = {
+      body: { foo },
+      cookies: { foo },
+      headers: { foo },
+      params: { foo },
+      query: { foo },
+    };
+
+    it(`creates a validation chain for ${locations.join(', ')}`, async () => {
+      const result = await createInstance()[method]('foo').isInt().run(req);
+      const errors = result.array() as FieldValidationError[];
+      expect(errors).toHaveLength(locations.length);
+      errors.forEach(error => {
+        expect(locations).toContain(error.location);
+      });
+    });
+
+    it('creates a validation chain with the extension methods', async () => {
+      const chain = createInstance()[method]('foo');
+      expect(chain.isAllowedDomain()).toBe(chain);
+      expect(chain.removeEmailAttribute()).toBe(chain);
+
+      await chain.run(req);
+      locations.forEach(location => {
+        const meta: Meta = { req, location, path: 'foo' };
+        expect(isAllowedDomain).toHaveBeenCalledWith(foo, meta);
+        expect(removeEmailAttribute).toHaveBeenCalledWith(foo, meta);
+      });
+    });
+  });
+
+  describe('#validationResult()', () => {
+    it('uses no error formatter by default', async () => {
+      const req = {};
+      const { check, validationResult } = new ExpressValidator();
+      await check('foo').exists().withMessage('not exists').run(req);
+
+      const [error] = validationResult(req).array();
+      expect(error).toEqual<ValidationError>({
+        type: 'field',
+        path: 'foo',
+        location: 'body',
+        value: undefined,
+        msg: 'not exists',
+      });
+    });
+
+    it('uses specified error formatter', async () => {
+      const req = {};
+      const { check, validationResult } = new ExpressValidator(undefined, undefined, {
+        errorFormatter: err => `${err.type}: ${err.msg}`,
+      });
+      await check('foo').exists().withMessage('not exists').run(req);
+
+      const [error] = validationResult(req).array();
+      expect(error).toBe('field: not exists');
+    });
+  });
+});

--- a/src/express-validator.ts
+++ b/src/express-validator.ts
@@ -119,6 +119,13 @@ export class ExpressValidator<
   ) {
     this.validatorEntries = Object.entries(validators || {});
     this.sanitizerEntries = Object.entries(sanitizers || {});
+
+    // Can't use arrow function in the declaration of `buildCheckFunction` due to the following
+    // error which only happens when tests are run without Jest cache (so CI only):
+    //
+    //    'buildCheckFunction' implicitly has type 'any' because it does not have a type annotation
+    //    and is referenced directly or indirectly in its own initializer
+    this.buildCheckFunction = this.buildCheckFunction.bind(this);
   }
 
   private createChain(
@@ -139,12 +146,12 @@ export class ExpressValidator<
     return Object.assign(middleware, boundValidators, boundSanitizers);
   }
 
-  readonly buildCheckFunction = (
+  buildCheckFunction(
     locations: Location[],
-  ): ((fields?: string | string[], message?: any) => CustomValidationChain<this>) => {
+  ): (fields?: string | string[], message?: any) => CustomValidationChain<this> {
     return (fields?: string | string[], message?: any) =>
       this.createChain(fields, locations, message);
-  };
+  }
 
   /**
    * Creates a middleware/validation chain for one or more fields that may be located in

--- a/src/express-validator.ts
+++ b/src/express-validator.ts
@@ -1,0 +1,172 @@
+import {
+  CustomSanitizer,
+  CustomValidator,
+  Location,
+  Middleware,
+  Request,
+  ValidationError,
+} from './base';
+import { ValidationChain } from './chain';
+import { MatchedDataOptions, matchedData } from './matched-data';
+import { check } from './middlewares/check';
+import { ErrorFormatter, Result, validationResult } from './validation-result';
+
+type CustomValidatorsMap = Record<string, CustomValidator>;
+type CustomSanitizersMap = Record<string, CustomSanitizer>;
+type CustomOptions<E = ValidationError> = {
+  errorFormatter?: ErrorFormatter<E>;
+};
+
+/**
+ * A validation chain that contains some extension validators/sanitizers.
+ *
+ * Built-in methods return the same chain type so that chaining using more of the extensions is
+ * possible.
+ *
+ * @example
+ * ```
+ * function createChain(chain: ValidationChainWithExtensions<'isAllowedDomain' | 'removeEmailAttribute'>) {
+ *  return chain
+ *    .isEmail()
+ *    .isAllowedDomain()
+ *    .trim()
+ *    .removeEmailAttribute();
+ * }
+ * ```
+ */
+export type ValidationChainWithExtensions<T extends string> = Middleware & {
+  [K in keyof ValidationChain]: ValidationChain[K] extends (...args: infer A) => ValidationChain
+    ? (...params: A) => ValidationChainWithExtensions<T>
+    : ValidationChain[K];
+} & {
+  [K in T]: () => ValidationChainWithExtensions<T>;
+};
+
+/* eslint-disable no-use-before-define */
+/**
+ * Type of a validation chain created by a custom ExpressValidator instance.
+ *
+ * @example
+ * ```
+ * const myExpressValidator = new ExpressValidator({
+ *  isAllowedDomain: value => value.endsWith('@gmail.com')
+ * });
+ *
+ * type MyCustomValidationChain = CustomValidationChain<typeof myExpressValidator>
+ * function createMyCustomChain(): MyCustomValidationChain {
+ *  return myExpressValidator.body('email').isAllowedDomain();
+ * }
+ * ```
+ */
+export type CustomValidationChain<T extends ExpressValidator<any, any, any>> =
+  T extends ExpressValidator<infer V, infer S, any>
+    ? ValidationChainWithExtensions<Extract<keyof V | keyof S, string>>
+    : never;
+
+/* eslint-enable no-use-before-define */
+
+export class ExpressValidator<
+  V extends CustomValidatorsMap = {},
+  S extends CustomSanitizersMap = {},
+  E = ValidationError,
+> {
+  private readonly validators: [keyof V, CustomValidator][];
+  private readonly sanitizers: [keyof S, CustomSanitizer][];
+
+  constructor(validators?: V, sanitizers?: S, private readonly options?: CustomOptions<E>) {
+    this.validators = Object.entries(validators || {});
+    this.sanitizers = Object.entries(sanitizers || {});
+  }
+
+  private createChain(
+    locations: Location[],
+    fields: string | string[] = '',
+    message?: any,
+  ): CustomValidationChain<this> {
+    const middleware = check(fields, locations, message) as CustomValidationChain<this>;
+
+    const boundValidators = Object.fromEntries(
+      this.validators.map(([name, fn]) => [name, () => middleware.custom(fn)]),
+    ) as Record<keyof V, () => CustomValidationChain<this>>;
+
+    const boundSanitizers = Object.fromEntries(
+      this.sanitizers.map(([name, fn]) => [name, () => middleware.customSanitizer(fn)]),
+    ) as Record<keyof S, () => CustomValidationChain<this>>;
+
+    return Object.assign(middleware, boundValidators, boundSanitizers);
+  }
+
+  readonly buildCheckFunction = (
+    locations: Location[],
+  ): ((fields?: string | string[], message?: any) => CustomValidationChain<this>) => {
+    return (fields?: string | string[], message?: any) =>
+      this.createChain(locations, fields, message);
+  };
+
+  /**
+   * Creates a middleware/validation chain for one or more fields that may be located in
+   * any of the following:
+   *
+   * - `req.body`
+   * - `req.cookies`
+   * - `req.headers`
+   * - `req.params`
+   * - `req.query`
+   *
+   * @param fields  a string or array of field names to validate/sanitize
+   * @param message an error message to use when failed validations don't specify a custom message.
+   *                Defaults to `Invalid Value`.
+   */
+  readonly check = this.buildCheckFunction(['body', 'cookies', 'headers', 'params', 'query']);
+
+  /**
+   * Same as {@link ExpressValidator.check}, but only validates in `req.body`.
+   */
+  readonly body = this.buildCheckFunction(['body']);
+
+  /**
+   * Same as {@link ExpressValidator.check}, but only validates in `req.cookies`.
+   */
+  readonly cookies = this.buildCheckFunction(['cookies']);
+
+  /**
+   * Same as {@link ExpressValidator.check}, but only validates in `req.headers`.
+   */
+  readonly headers = this.buildCheckFunction(['headers']);
+
+  /**
+   * Same as {@link ExpressValidator.check}, but only validates in `req.params`.
+   */
+  readonly params = this.buildCheckFunction(['params']);
+
+  /**
+   * Same as {@link ExpressValidator.check}, but only validates in `req.query`.
+   */
+  readonly query = this.buildCheckFunction(['query']);
+
+  /**
+   * Extracts the validation errors of an express request using the default error formatter of this
+   * instance.
+   *
+   * @see {@link validationResult()}
+   * @param req the express request object
+   * @returns a `Result` which will by default use the error formatter passed when
+   *          instantiating `ExpressValidator`.
+   */
+  readonly validationResult = (req: Request): Result<E> => {
+    const formatter = this.options?.errorFormatter;
+    const result = validationResult(req);
+    return formatter ? result.formatWith(formatter) : (result as unknown as Result<E>);
+  };
+
+  /**
+   * Extracts data validated or sanitized from the request, and builds an object with them.
+   *
+   * This method is a shortcut for `matchedData`; it does nothing different than it.
+   *
+   * @see {@link matchedData}
+   */
+  matchedData(req: Request, options?: Partial<MatchedDataOptions>): Record<string, any> {
+    return matchedData(req, options);
+  }
+}

--- a/src/express-validator.ts
+++ b/src/express-validator.ts
@@ -10,6 +10,7 @@ import {
 import { ContextRunner, ValidationChain } from './chain';
 import { MatchedDataOptions, matchedData } from './matched-data';
 import { check } from './middlewares/check';
+import { checkExact } from './middlewares/exact';
 import { OneOfErrorType, OneOfOptions, oneOf } from './middlewares/one-of';
 import {
   DefaultSchemaKeys,
@@ -185,6 +186,15 @@ export class ExpressValidator<
    * Same as {@link ExpressValidator.check}, but only validates in `req.query`.
    */
   readonly query = this.buildCheckFunction(['query']);
+
+  /**
+   * Checks whether the request contains exactly only those fields that have been validated.
+   *
+   * This method is here for convenience; it does exactly the same as `checkExact`.
+   *
+   * @see {@link checkExact}
+   */
+  readonly checkExact = checkExact;
 
   /**
    * Creates an express middleware with validations for multiple fields at once in the form of

--- a/src/express-validator.ts
+++ b/src/express-validator.ts
@@ -1,4 +1,5 @@
 import {
+  AlternativeMessageFactory,
   CustomSanitizer,
   CustomValidator,
   Location,
@@ -6,9 +7,10 @@ import {
   Request,
   ValidationError,
 } from './base';
-import { ValidationChain } from './chain';
+import { ContextRunner, ValidationChain } from './chain';
 import { MatchedDataOptions, matchedData } from './matched-data';
 import { check } from './middlewares/check';
+import { OneOfErrorType, OneOfOptions, oneOf } from './middlewares/one-of';
 import {
   DefaultSchemaKeys,
   ExtensionSanitizerSchemaOptions,
@@ -200,6 +202,46 @@ export class ExpressValidator<
     schema: CustomSchema<this, T>,
     locations?: Location[],
   ) => RunnableValidationChains<CustomValidationChain<this>>;
+
+  /**
+   * Creates a middleware that will ensure that at least one of the given validation chains
+   * or validation chain groups are valid.
+   *
+   * If none are, a single error of type `alternative` is added to the request,
+   * with the errors of each chain made available under the `nestedErrors` property.
+   *
+   * @param chains an array of validation chains to check if are valid.
+   *               If any of the items of `chains` is an array of validation chains, then all of them
+   *               must be valid together for the request to be considered valid.
+   * @param options.message a function for creating a custom error message in case none of the chains are valid
+   */
+  oneOf(
+    chains: (CustomValidationChain<this> | CustomValidationChain<this>[])[],
+    options?: { message?: AlternativeMessageFactory; errorType?: OneOfErrorType },
+  ): Middleware & ContextRunner;
+
+  /**
+   * Creates a middleware that will ensure that at least one of the given validation chains
+   * or validation chain groups are valid.
+   *
+   * If none are, a single error of type `alternative` is added to the request,
+   * with the errors of each chain made available under the `nestedErrors` property.
+   *
+   * @param chains an array of validation chains to check if are valid.
+   *               If any of the items of `chains` is an array of validation chains, then all of them
+   *               must be valid together for the request to be considered valid.
+   * @param options.message an error message to use in case none of the chains are valid
+   */
+  oneOf(
+    chains: (CustomValidationChain<this> | CustomValidationChain<this>[])[],
+    options?: { message?: any; errorType?: OneOfErrorType },
+  ): Middleware & ContextRunner;
+  oneOf(
+    chains: (CustomValidationChain<this> | CustomValidationChain<this>[])[],
+    options?: OneOfOptions,
+  ) {
+    return oneOf(chains, options);
+  }
 
   /**
    * Extracts the validation errors of an express request using the default error formatter of this

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export { checkSchema, Schema, ParamSchema } from './middlewares/schema';
 
 export * from './matched-data';
 export * from './validation-result';
+export * from './express-validator';


### PR DESCRIPTION
## Description

This adds the `ExpressValidator` class, which can hold extension validators, sanitisers and default result formatters.

It can be used like this:

```js
const { check, body, checkSchema, validationResult } = new ExpressValidator(
	// Custom validators
	{ isAllowedDomain: value => { ... } },
	// Custom sanitizers
	{ removeDomain: value => { ... } },
	// Options. Currently only errorFormatter
	{ errorFormatter: error => `Error of type ${error.type}` },
);

app.post('/new-user', [
	check('email')
		.trim()
		.isEmail()
		.isAllowedDomain()
		.removeDomain()
], (req, res) => {
	console.log(validationResult(req).array());
	// => 'Error of type field'
});
```

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
