### PR TITLE
Request-level bail

### DIFF
--- a/src/chain/context-handler-impl.spec.ts
+++ b/src/chain/context-handler-impl.spec.ts
@@ -10,6 +10,7 @@ let contextHandler: ContextHandler<any>;
 beforeEach(() => {
   builder = new ContextBuilder();
   jest.spyOn(builder, 'setOptional');
+  jest.spyOn(builder, 'setRequestBail');
   jest.spyOn(builder, 'addItem');
 
   contextHandler = new ContextHandlerImpl(builder, {});
@@ -19,6 +20,17 @@ describe('#bail()', () => {
   it('adds a Bail item', () => {
     contextHandler.bail();
     expect(builder.addItem).toHaveBeenCalledWith(new Bail());
+  });
+
+  it('does not sets request bail if level is unset or set to chain', () => {
+    contextHandler.bail({});
+    contextHandler.bail({ level: 'chain' });
+    expect(builder.setRequestBail).not.toHaveBeenCalled();
+  });
+
+  it('sets request bail if level is set to request', () => {
+    contextHandler.bail({ level: 'request' });
+    expect(builder.setRequestBail).toHaveBeenCalled();
   });
 });
 

--- a/src/chain/context-handler-impl.spec.ts
+++ b/src/chain/context-handler-impl.spec.ts
@@ -22,7 +22,7 @@ describe('#bail()', () => {
     expect(builder.addItem).toHaveBeenCalledWith(new Bail());
   });
 
-  it('does not sets request bail if level is unset or set to chain', () => {
+  it('does not set request bail if level is unset or set to chain', () => {
     contextHandler.bail({});
     contextHandler.bail({ level: 'chain' });
     expect(builder.setRequestBail).not.toHaveBeenCalled();

--- a/src/chain/context-handler-impl.ts
+++ b/src/chain/context-handler-impl.ts
@@ -3,13 +3,13 @@ import { Optional } from '../context';
 import { ChainCondition, CustomCondition } from '../context-items';
 import { CustomValidator } from '../base';
 import { Bail } from '../context-items/bail';
-import { ContextHandler } from './context-handler';
+import { BailOptions, ContextHandler } from './context-handler';
 import { ContextRunner } from './context-runner';
 
 export class ContextHandlerImpl<Chain> implements ContextHandler<Chain> {
   constructor(private readonly builder: ContextBuilder, private readonly chain: Chain) {}
 
-  bail(opts?: { level?: 'chain' | 'request' }) {
+  bail(opts?: BailOptions) {
     if (opts?.level === 'request') {
       this.builder.setRequestBail();
     }

--- a/src/chain/context-handler-impl.ts
+++ b/src/chain/context-handler-impl.ts
@@ -9,7 +9,10 @@ import { ContextRunner } from './context-runner';
 export class ContextHandlerImpl<Chain> implements ContextHandler<Chain> {
   constructor(private readonly builder: ContextBuilder, private readonly chain: Chain) {}
 
-  bail() {
+  bail(opts?: { level?: 'chain' | 'request' }) {
+    if (opts?.level === 'request') {
+      this.builder.setRequestBail();
+    }
     this.builder.addItem(new Bail());
     return this.chain;
   }

--- a/src/chain/context-handler.ts
+++ b/src/chain/context-handler.ts
@@ -2,6 +2,19 @@ import { CustomValidator } from '../base';
 import { Optional } from '../context';
 import { ContextRunner } from './context-runner';
 
+export interface BailOptions {
+  /**
+   * Defines the level at which to stop running further validations:
+   * - When set to `chain`, further validations won't be run for this validation chain if there
+   *   are any errors.
+   * - When set to `request`, no further validations on the same request will be run either if
+   *   there are any errors.
+   *
+   * @default 'chain'
+   */
+  level?: 'chain' | 'request';
+}
+
 export interface ContextHandler<Chain> {
   /**
    * Stops running validations if any of the previous ones have failed.
@@ -23,18 +36,7 @@ export interface ContextHandler<Chain> {
    *
    * @returns the current validation chain
    */
-  bail(opts?: {
-    /**
-     * Defines the level at which to stop running further validations:
-     * - When set to `chain`, further validations won't be run for this validation chain if there
-     *   are any errors.
-     * - When set to `request`, no further validations on the same request will be run either if
-     *   there are any errors.
-     *
-     * @default 'chain'
-     */
-    level?: 'chain' | 'request';
-  }): Chain;
+  bail(opts?: BailOptions): Chain;
 
   /**
    * Adds a condition on whether the validation should continue on a field or not.

--- a/src/chain/context-handler.ts
+++ b/src/chain/context-handler.ts
@@ -23,7 +23,18 @@ export interface ContextHandler<Chain> {
    *
    * @returns the current validation chain
    */
-  bail(): Chain;
+  bail(opts?: {
+    /**
+     * Defines the level at which to stop running further validations:
+     * - When set to `chain`, further validations won't be run for this validation chain if there
+     *   are any errors.
+     * - When set to `request`, no further validations on the same request will be run either if
+     *   there are any errors.
+     *
+     * @default 'chain'
+     */
+    level?: 'chain' | 'request';
+  }): Chain;
 
   /**
    * Adds a condition on whether the validation should continue on a field or not.

--- a/src/chain/context-runner-impl.spec.ts
+++ b/src/chain/context-runner-impl.spec.ts
@@ -113,6 +113,19 @@ it('runs items on the stack in order', async () => {
   return resultPromise;
 });
 
+it('does not run items if a previous context halts the whole request', async () => {
+  const context1 = new ContextBuilder().setRequestBail().build();
+  const context2 = new ContextBuilder().addItem({ run: jest.fn() }).build();
+
+  const req = {};
+  context1.addError({ type: 'field', value: 1, meta: { req, location: 'params', path: 'foo' } });
+
+  await new ContextRunnerImpl(context1, selectFields).run(req);
+  await new ContextRunnerImpl(context2, selectFields).run(req);
+
+  expect(context2.stack[0].run).not.toHaveBeenCalled();
+});
+
 it('stops running items on paths that got a validation halt', async () => {
   builder.addItem(
     {

--- a/src/chain/context-runner-impl.ts
+++ b/src/chain/context-runner-impl.ts
@@ -23,6 +23,15 @@ export class ContextRunnerImpl implements ContextRunner {
       this.builderOrContext instanceof Context
         ? this.builderOrContext
         : this.builderOrContext.build();
+
+    const internalReq = req as InternalRequest;
+    const bail = internalReq[contextsKey]?.some(
+      context => context.bail && context.errors.length > 0,
+    );
+    if (bail) {
+      return new ResultWithContextImpl(context);
+    }
+
     const instances = this.selectFields(req, context.fields, context.locations);
     context.addFieldInstances(instances);
 
@@ -66,7 +75,6 @@ export class ContextRunnerImpl implements ContextRunner {
     }
 
     if (!options.dryRun) {
-      const internalReq = req as InternalRequest;
       internalReq[contextsKey] = (internalReq[contextsKey] || []).concat(context);
     }
 

--- a/src/chain/context-runner.ts
+++ b/src/chain/context-runner.ts
@@ -2,7 +2,7 @@ import { Request, ValidationError } from '../base';
 import { ReadonlyContext } from '../context';
 import { Result } from '../validation-result';
 
-type ContextRunningOptions = {
+export type ContextRunningOptions = {
   /**
    * Defines whether errors and sanitization should be persisted to `req`.
    * @default false

--- a/src/chain/validation-chain.ts
+++ b/src/chain/validation-chain.ts
@@ -13,3 +13,14 @@ export interface ValidationChain
   (req: Request, res: any, next: (error?: any) => void): void;
   builder: ContextBuilder;
 }
+
+/**
+ * A copy of `ValidationChain` where methods that would return the chain itself can return any other
+ * value.
+ * Useful for typing functions which accept either standard or custom validation chains.
+ */
+export type ValidationChainLike = {
+  [K in keyof ValidationChain]: ValidationChain[K] extends (...args: infer A) => ValidationChain
+    ? (...args: A) => any
+    : ValidationChain[K];
+};

--- a/src/context-builder.spec.ts
+++ b/src/context-builder.spec.ts
@@ -37,6 +37,16 @@ describe('#setOptional()', () => {
   });
 });
 
+describe('#setRequestBail()', () => {
+  it('builders a Context with the bail flag set', () => {
+    let context = builder.build();
+    expect(context.bail).toBe(false);
+
+    context = builder.setRequestBail().build();
+    expect(context.bail).toBe(true);
+  });
+});
+
 describe('#addItem()', () => {
   it('builds a Context with all the item pushed to the stack', () => {
     const item1: ContextItem = {

--- a/src/context-builder.ts
+++ b/src/context-builder.ts
@@ -8,6 +8,7 @@ export class ContextBuilder {
   private locations: Location[] = [];
   private message: any;
   private optional: Optional = false;
+  private requestBail = false;
 
   setFields(fields: string[]) {
     this.fields = fields;
@@ -34,7 +35,19 @@ export class ContextBuilder {
     return this;
   }
 
+  setRequestBail() {
+    this.requestBail = true;
+    return this;
+  }
+
   build() {
-    return new Context(this.fields, this.locations, this.stack, this.optional, this.message);
+    return new Context(
+      this.fields,
+      this.locations,
+      this.stack,
+      this.optional,
+      this.requestBail,
+      this.message,
+    );
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -69,6 +69,7 @@ export class Context {
     readonly locations: Location[],
     readonly stack: ReadonlyArray<ContextItem>,
     readonly optional: Optional,
+    readonly bail: boolean,
     readonly message?: any,
   ) {}
 

--- a/src/middlewares/exact.ts
+++ b/src/middlewares/exact.ts
@@ -10,6 +10,7 @@ import {
 import { ContextRunner, ResultWithContextImpl, ValidationChain } from '../chain';
 import { Context } from '../context';
 import { selectUnknownFields } from '../field-selection';
+import { runAllChains } from '../utils';
 
 type CheckExactOptions = {
   /**
@@ -79,8 +80,7 @@ export function checkExact(
     const internalReq = req as InternalRequest;
 
     const fieldsByLocation = new Map<Location, string[]>();
-    const promises = chainsArr.map(async chain => chain.run(req));
-    await Promise.all(promises);
+    await runAllChains(req, chainsArr);
 
     // The chains above will have added contexts to the request
     (internalReq[contextsKey] || []).forEach(context => {

--- a/src/middlewares/exact.ts
+++ b/src/middlewares/exact.ts
@@ -105,7 +105,7 @@ export function checkExact(
       unknownFields = unknownFields.concat(selectUnknownFields(req, fields, [location]));
     }
 
-    const context = new Context([], [], [], false);
+    const context = new Context([], [], [], false, false);
     if (unknownFields.length) {
       context.addError({
         type: 'unknown_fields',

--- a/src/middlewares/one-of.spec.ts
+++ b/src/middlewares/one-of.spec.ts
@@ -107,6 +107,21 @@ describe('with a list of chain groups', () => {
       done();
     });
   });
+
+  it('stops running chains in a group when one of them has errors and request-level bail', done => {
+    const req = {
+      cookies: { foo: true, bar: 'def', baz: 'qux' },
+    };
+
+    const custom = jest.fn();
+    oneOf([
+      [check('foo').isInt().bail({ level: 'request' }), check('bar').custom(custom)],
+      check('baz').isAlpha(),
+    ])(req, {}, () => {
+      expect(custom).not.toHaveBeenCalled();
+      done();
+    });
+  });
 });
 
 describe('error message', () => {

--- a/src/middlewares/schema.spec.ts
+++ b/src/middlewares/schema.spec.ts
@@ -352,6 +352,24 @@ describe('on schema that contains fields with bail methods', () => {
     const { context } = await schema[0].run({ params: { foo: 'notAnEmail' } });
     expect(context.errors).toHaveLength(1);
   });
+
+  it('support request-level bail methods', async () => {
+    const schema = checkSchema({
+      foo: {
+        isEmail: {
+          bail: { level: 'request' },
+        },
+      },
+      bar: {
+        isEmail: true,
+      },
+    });
+
+    const contexts = await schema.run({ params: { foo: 'notAnEmail' } });
+    // there's no second context, as the second chain wasn't run.
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].array()).toHaveLength(1);
+  });
 });
 
 it('run checkSchema imperatively', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { Request } from './base';
+import { ContextRunningOptions, ResultWithContext, ValidationChainLike } from './chain';
+
 export const bindAll = <T>(object: T): { [K in keyof T]: T[K] } => {
   const protoKeys = Object.getOwnPropertyNames(Object.getPrototypeOf(object)) as (keyof T)[];
   protoKeys.forEach(key => {
@@ -23,4 +26,35 @@ export function toString(value: any): string {
   }
 
   return String(value);
+}
+
+/**
+ * Runs all validation chains, and returns their results.
+ *
+ * If one of them has a request-level bail set, the previous chains will be awaited on so that
+ * results are not skewed, which can be slow.
+ * If this same chain also contains errors, no further chains are run.
+ */
+export async function runAllChains(
+  req: Request,
+  chains: readonly ValidationChainLike[],
+  runOpts?: ContextRunningOptions,
+): Promise<ResultWithContext[]> {
+  const promises: Promise<ResultWithContext>[] = [];
+  for (const chain of chains) {
+    const bails = chain.builder.build().bail;
+    if (bails) {
+      await Promise.all(promises);
+    }
+
+    const resultPromise = chain.run(req, runOpts);
+    promises.push(resultPromise);
+    if (bails) {
+      const result = await resultPromise;
+      if (!result.isEmpty()) {
+        break;
+      }
+    }
+  }
+  return Promise.all(promises);
 }


### PR DESCRIPTION
## Description

Closes #1100

Implements an option to `.bail()` so that no further contexts will run if there are any errors.

Supports:
- [x] `oneOf`
- [x] `checkSchema`
- [x] `checkExact`


⚠️ This is a perf-loss for those using any of the above functions, as the chains now need to be awaited on, otherwise results will be unreliable.

Suppose that you have a request with 1k fields, one validator on each field, each taking 10ms to complete.
Also suppose that no fields present errors, so every validator runs.

On my machine, the time it takes for running all validation chains looks like this:
- **With request-level bail on every field:** 10s
- **With request-level bail on half of all fields:** 10s (no difference)
- **With request-level bail on a third of all fields:** ~7s (roughly 1/3 better than the above scenarios)
- **Without request-level bail:** ~100 ms.

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
