### PR TITLE
Rename field using custom validator

### DIFF
--- a/src/context-items/custom-validation.ts
+++ b/src/context-items/custom-validation.ts
@@ -20,8 +20,8 @@ export class CustomValidation implements ContextItem {
         context.addError(this.message, value, meta);
       }
       // rename field if return type is string
-      if (typeof actualResult === "string") {
-          context.renameFieldInstance(actualResult, meta)
+      if (typeof actualResult === 'string') {
+        context.renameFieldInstance(actualResult, meta);
       }
     } catch (err) {
       if (this.negated) {

--- a/src/context-items/custom-validation.ts
+++ b/src/context-items/custom-validation.ts
@@ -19,6 +19,10 @@ export class CustomValidation implements ContextItem {
       if ((!isPromise && failed) || (isPromise && this.negated)) {
         context.addError(this.message, value, meta);
       }
+      // rename field if return type is string
+      if (typeof actualResult === "string") {
+          context.renameFieldInstance(actualResult, meta)
+      }
     } catch (err) {
       if (this.negated) {
         return;

--- a/src/context.ts
+++ b/src/context.ts
@@ -112,6 +112,13 @@ export class Context {
     if (!instance) {
       throw new Error('Attempt to rename field that did not pre-exist in context');
     }
+    const { originalPath } = instance;
+    if (this.fields.length !== 1) {
+      throw new Error('Attempt to rename multiple fields.');
+    }
+    if (/\.|\*/g.test(originalPath)) {
+      throw new Error('Attempt to rename a wildcard field');
+    }
     instance.path = newPath;
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -106,6 +106,14 @@ export class Context {
       });
     }
   }
+  renameFieldInstance(newPath: string, meta: Meta) {
+    const { path, location } = meta;
+    const instance = this.dataMap.get(getDataMapKey(path, location));
+    if (!instance) {
+      throw new Error('Attempt to rename field that did not pre-exist in context');
+    }
+    instance.path = newPath;
+  }
 }
 
 export type ReadonlyContext = Pick<


### PR DESCRIPTION
## Description
This allows to rename parameters using custom validator.

Example
```js
app.post(
    "/user",
    // Promise
    body("search").custom((value) => {
        return new Promise((resolve, reject) => {
            if (value.includes("@")) {
                return resolve("email");
            }
            resolve();
        });
    }),
    // Basic 
    check("search")
        .custom((value) => {
            if (value.includes("+")) {
                return "phone";
            }
            return false;
        })
        .withMessage("An error occurred"),
    (req, res) => {
        // Handle the request
    }
);
```
closes: #785 

## To-do list
- [ ] Wildcard support

- [ ] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
