### PR TITLE
docs: prefer `const` over `let`

### DIFF
--- a/docs/guides/manually-running.md
+++ b/docs/guides/manually-running.md
@@ -30,7 +30,7 @@ const { validationResult, ValidationChain } = require('express-validator');
 // sequential processing, stops running validations chain if the previous one fails.
 const validate = validations => {
   return async (req, res, next) => {
-    for (let validation of validations) {
+    for (const validation of validations) {
       const result = await validation.run(req);
       if (result.errors.length) break;
     }

--- a/docs/guides/manually-running.md
+++ b/docs/guides/manually-running.md
@@ -64,7 +64,7 @@ import { body, validationResult, ValidationChain } from 'express-validator';
 // sequential processing, stops running validations chain if the previous one fails.
 const validate = (validations: ValidationChain[]) => {
   return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-    for (let validation of validations) {
+    for (const validation of validations) {
       const result = await validation.run(req);
       if (result.errors.length) break;
     }


### PR DESCRIPTION
## Description

A small change in the example to use `const` because the variable is not reassigned 

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] I have added tests for what I changed.

- [x] This pull request is ready to merge.
