### PR TITLE
Typo of ValidationSchema

### DIFF
--- a/docs/migration-v6-to-v7.md
+++ b/docs/migration-v6-to-v7.md
@@ -39,7 +39,7 @@ The following types have been removed from express-validator and can be transpar
 | From                    | To            |
 | ----------------------- | ------------- |
 | `ValidationParamSchema` | `ParamSchema` |
-| `Validationchema`       | `Schema`      |
+| `ValidationSchema`       | `Schema`      |
 
 ## Validators
 


### PR DESCRIPTION
Small typo in the Documentation for the change from `ValidationSchema` to `Schema`

## Description
Found a typo while reading the documentation. Small fix describing the upgrade form 6 to 7 and the remove of `ValidationSchema`

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
