### PR TITLE
docs(guide/manually-running) typescript example should use `ContextRunner`

### DIFF
--- a/docs/guides/manually-running.md
+++ b/docs/guides/manually-running.md
@@ -24,7 +24,7 @@ Check the examples below to understand how this method can help you:
 
 ```js
 const express = require('express');
-const { validationResult, ValidationChain } = require('express-validator');
+const { validationResult } = require('express-validator');
 // can be reused by many routes
 
 // sequential processing, stops running validations chain if the previous one fails.
@@ -58,11 +58,11 @@ app.post('/signup', validate([
 
 ```typescript
 import express from 'express';
-import { body, validationResult, ValidationChain } from 'express-validator';
+import { body, validationResult, ContextRunner } from 'express-validator';
 // can be reused by many routes
 
 // sequential processing, stops running validations chain if the previous one fails.
-const validate = (validations: ValidationChain[]) => {
+const validate = (validations: ContextRunner[]) => {
   return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     for (const validation of validations) {
       const result = await validation.run(req);

--- a/website/versioned_docs/version-7.0.0/guides/manually-running.md
+++ b/website/versioned_docs/version-7.0.0/guides/manually-running.md
@@ -24,7 +24,7 @@ Check the examples below to understand how this method can help you:
 
 ```js
 const express = require('express');
-const { validationResult, ValidationChain } = require('express-validator');
+const { validationResult } = require('express-validator');
 // can be reused by many routes
 
 // sequential processing, stops running validations chain if the previous one fails.
@@ -58,11 +58,11 @@ app.post('/signup', validate([
 
 ```typescript
 import express from 'express';
-import { body, validationResult, ValidationChain } from 'express-validator';
+import { body, validationResult, ContextRunner } from 'express-validator';
 // can be reused by many routes
 
 // sequential processing, stops running validations chain if the previous one fails.
-const validate = (validations: ValidationChain[]) => {
+const validate = (validations: ContextRunner[]) => {
   return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     for (let validation of validations) {
       const result = await validation.run(req);


### PR DESCRIPTION
## Description

The "manually running" guide's typescript example should use `ContextRunner` instead of `ValidationChain` as it is a more minimal interface required by the example helper.

## To-do list

- [x] I have added tests for what I changed.
- [x] This pull request is ready to merge.
