### PR TITLE
feat: ignoreUndefined in includeOptional

### DIFF
--- a/src/chain/context-runner-impl.ts
+++ b/src/chain/context-runner-impl.ts
@@ -38,7 +38,7 @@ export class ContextRunnerImpl implements ContextRunner {
     const haltedInstances = new Set<string>();
 
     for (const contextItem of context.stack) {
-      const promises = context.getData({ requiredOnly: true }).map(async instance => {
+      const promises = context.getData({ includeOptionals: false }).map(async instance => {
         const { location, path } = instance;
         const instanceKey = `${location}:${path}`;
         if (haltedInstances.has(instanceKey)) {

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -297,7 +297,7 @@ describe('#getData()', () => {
     context = new ContextBuilder().setOptional('undefined').build();
     context.addFieldInstances(data);
 
-    expect(context.getData({ requiredOnly: true })).toEqual([data[1]]);
+    expect(context.getData({ includeOptionals: false })).toEqual([data[1]]);
   });
 
   it('filters out undefineds and nulls when context optional = null', () => {
@@ -307,7 +307,7 @@ describe('#getData()', () => {
     context = new ContextBuilder().setOptional('null').build();
     context.addFieldInstances(data);
 
-    expect(context.getData({ requiredOnly: true })).toEqual([]);
+    expect(context.getData({ includeOptionals: false })).toEqual([]);
   });
 
   it('filters out falsies when context optional = falsy', () => {
@@ -318,7 +318,7 @@ describe('#getData()', () => {
     context = new ContextBuilder().setOptional('falsy').build();
     context.addFieldInstances(data);
 
-    expect(context.getData({ requiredOnly: true })).toEqual([]);
+    expect(context.getData({ includeOptionals: false })).toEqual([]);
   });
 
   describe('when same path occurs multiple times', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,6 +9,7 @@ import {
   ValidationError,
 } from './base';
 import { ContextItem } from './context-items';
+import { IncludeOptionals } from './matched-data';
 
 function getDataMapKey(path: string, location: Location) {
   return `${location}:${path}`;
@@ -67,10 +68,10 @@ export class Context {
     readonly message?: any,
   ) {}
 
-  getData(options: { requiredOnly: boolean } = { requiredOnly: false }) {
+  getData(options: { includeOptionals: IncludeOptionals } = { includeOptionals: true }) {
     const { optional } = this;
     const checks =
-      options.requiredOnly && optional
+      !options.includeOptionals && optional
         ? [
             (value: any) => value !== undefined,
             (value: any) => (optional === 'null' ? value != null : true),
@@ -94,7 +95,13 @@ export class Context {
 
         return instances;
       })
-      .filter(instance => checks.every(check => check(instance.value)))
+      .filter(instance => {
+        if (options.includeOptionals === 'ignoreUndefined') {
+          return checks.every(check => check(instance.value)) && instance.value !== undefined
+        } else {
+          return checks.every(check => check(instance.value))
+        }
+      })
       .valueOf();
   }
 

--- a/src/matched-data.spec.ts
+++ b/src/matched-data.spec.ts
@@ -73,6 +73,25 @@ describe('when option includeOptionals is true', () => {
   });
 });
 
+describe('when option includeOptionals is ignoreUndefined ', () => {
+  it('returns object with optional data which is not undefined', done => {
+    const req = {
+      headers: { foo: '123', bar: null },
+    };
+
+    const middleware = check(['foo', 'bar', 'baz']).optional({ values: 'null' }).isInt();
+
+    middleware(req, {}, () => {
+      const data = matchedData(req, { includeOptionals: 'ignoreUndefined' });
+      expect(data).toHaveProperty('foo', '123');
+      expect(data).toHaveProperty('bar', null);
+      expect(data).not.toHaveProperty('baz');
+
+      done();
+    });
+  });
+});
+
 describe('when option onlyValidData is false', () => {
   it('returns object with invalid data', done => {
     const req = {

--- a/src/matched-data.ts
+++ b/src/matched-data.ts
@@ -7,12 +7,21 @@ interface FieldInstanceBag {
   context: Context;
 }
 
+/**
+ * Defines if includes optional data or not.
+ *
+ * - false: not include optional data
+ * - true: include optional data
+ * - `ignoreUndefined`: include optional data which is not undefined like null, falsy values
+ */
+export type IncludeOptionals = boolean | 'ignoreUndefined';
+
 export type MatchedDataOptions = {
   /**
    * Whether the value returned by `matchedData()` should include data deemed optional.
    * @default false
    */
-  includeOptionals: boolean;
+  includeOptionals: IncludeOptionals;
 
   /**
    * An array of locations in the request to extract the data from.
@@ -39,10 +48,11 @@ export function matchedData<T extends object = Record<string, any>>(
   options: Partial<MatchedDataOptions> = {},
 ): T {
   const internalReq: InternalRequest = req;
+  const { includeOptionals = false, onlyValidData, locations } = options;
 
-  const fieldExtractor = createFieldExtractor(options.includeOptionals !== true);
-  const validityFilter = createValidityFilter(options.onlyValidData);
-  const locationFilter = createLocationFilter(options.locations);
+  const fieldExtractor = createFieldExtractor(includeOptionals);
+  const validityFilter = createValidityFilter(onlyValidData);
+  const locationFilter = createLocationFilter(locations);
 
   return _(internalReq[contextsKey])
     .flatMap(fieldExtractor)
@@ -52,9 +62,9 @@ export function matchedData<T extends object = Record<string, any>>(
     .reduce((state, instance) => _.set(state, instance.path, instance.value), {} as T);
 }
 
-function createFieldExtractor(removeOptionals: boolean) {
+function createFieldExtractor(includeOptionals: IncludeOptionals) {
   return (context: Context) => {
-    const instances = context.getData({ requiredOnly: removeOptionals });
+    const instances = context.getData({ includeOptionals: includeOptionals });
     return instances.map((instance): FieldInstanceBag => ({ instance, context }));
   };
 }


### PR DESCRIPTION
## Description

Add `ignoreUndefined` to `includeOptionals` in `matchedData`

`ignoreUndefined` allows  user to pass optional values which aren't undefined like null and falsy values.
It keeps current behaviour and allow user to customize matchedData.

#1048 
#1175 
#1273 

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [ x] This pull request is ready to merge.
