### PR TITLE
docs: typescript example should use isEmpty method (guide/manually-running)

### DIFF
--- a/docs/guides/manually-running.md
+++ b/docs/guides/manually-running.md
@@ -66,7 +66,7 @@ const validate = (validations: ContextRunner[]) => {
   return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     for (const validation of validations) {
       const result = await validation.run(req);
-      if (result.errors.length) break;
+      if (!result.isEmpty()) break;
     }
 
     const errors = validationResult(req);


### PR DESCRIPTION
## Description

<!-- Describe what you changed and link to the relevant issue(s) -->
## The example in the manual run guide in the official document does not work, 

The errors property of the Result<T> class in validation-result.ts is not accessible because it is a private property.
- I thought about opening the errors property as public, but I didn't think it was a good way to encapsulate it

### It states that the isEmpty method in the Result<T> class has the following roles
![1123](https://github.com/express-validator/express-validator/assets/65344293/52f1ec06-b058-4d31-8a6d-b4a70bd5abf1)


## Therefore, you must use the isEmpty() method of the Result<T> class to determine the presence or absence of an error

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
