### PR TITLE
fix: correctly select properties of primitives

### DIFF
--- a/src/express-validator.spec.ts
+++ b/src/express-validator.spec.ts
@@ -165,22 +165,3 @@ describe('ExpressValidator', () => {
     });
   });
 });
-
-describe('High level tests', () => {
-  const { body } = new ExpressValidator();
-  it('should error when .exists() is used on a nested field of a primitive', async () => {
-    const req = { body: { foo: 'hello' } };
-    const result = await body('foo.nop').exists().run(req);
-    expect(result.isEmpty()).toEqual(false);
-  });
-  it('should not error when .not().exists() is used on a nested field of a primitive', async () => {
-    const req = { body: { foo: 'hello' } };
-    const result = await body('foo.nop').not().exists().run(req);
-    expect(result.isEmpty()).toEqual(true);
-  });
-  it('should not error when .exists() is used on a nested field of a primitive using wildcard', async () => {
-    const req = { body: { foo: 'hello' } };
-    const result = await body('foo.*.nop').exists().run(req);
-    expect(result.isEmpty()).toEqual(true);
-  });
-});

--- a/src/express-validator.spec.ts
+++ b/src/express-validator.spec.ts
@@ -165,3 +165,22 @@ describe('ExpressValidator', () => {
     });
   });
 });
+
+describe('High level tests', () => {
+  const { body } = new ExpressValidator();
+  it('should error when .exists() is used on a nested field of a primitive', async () => {
+    const req = { body: { foo: "hello" } };
+    const result = await body("foo.nop").exists().run(req);
+    expect(result.isEmpty()).toEqual(false);
+  })
+  it('should not error when .not().exists() is used on a nested field of a primitive', async () => {
+    const req = { body: { foo: 'hello' } };
+    const result = await body('foo.nop').not().exists().run(req);
+    expect(result.isEmpty()).toEqual(true);
+  });
+  it('should not error when .exists() is used on a nested field of a primitive using wildcard', async () => {
+    const req = { body: { foo: 'hello' } };
+    const result = await body('foo.*.nop').exists().run(req);
+    expect(result.isEmpty()).toEqual(true);
+  });
+})

--- a/src/express-validator.spec.ts
+++ b/src/express-validator.spec.ts
@@ -169,10 +169,10 @@ describe('ExpressValidator', () => {
 describe('High level tests', () => {
   const { body } = new ExpressValidator();
   it('should error when .exists() is used on a nested field of a primitive', async () => {
-    const req = { body: { foo: "hello" } };
-    const result = await body("foo.nop").exists().run(req);
+    const req = { body: { foo: 'hello' } };
+    const result = await body('foo.nop').exists().run(req);
     expect(result.isEmpty()).toEqual(false);
-  })
+  });
   it('should not error when .not().exists() is used on a nested field of a primitive', async () => {
     const req = { body: { foo: 'hello' } };
     const result = await body('foo.nop').not().exists().run(req);
@@ -183,4 +183,4 @@ describe('High level tests', () => {
     const result = await body('foo.*.nop').exists().run(req);
     expect(result.isEmpty()).toEqual(true);
   });
-})
+});

--- a/src/field-selection.spec.ts
+++ b/src/field-selection.spec.ts
@@ -19,14 +19,16 @@ describe('selectFields()', () => {
     const instances = selectFields(req, ['foo', 'baz'], ['cookies']);
 
     expect(instances).toHaveLength(2);
-    expect(instances[0]).toMatchObject({
+    expect(instances[0]).toEqual({
       location: 'cookies',
       path: 'foo',
+      originalPath: 'foo',
       value: 'bar',
     });
-    expect(instances[1]).toMatchObject({
+    expect(instances[1]).toEqual({
       location: 'cookies',
       path: 'baz',
+      originalPath: 'baz',
       value: 'qux',
     });
   });
@@ -113,13 +115,18 @@ describe('selectFields()', () => {
     const req = {
       query: { foo: ['bar', 'baz'] },
     };
-    const instances = selectFields(req, ['foo[1]'], ['query']);
+    const instances = selectFields(req, ['foo[1]', 'foo[2]'], ['query']);
 
-    expect(instances).toHaveLength(1);
+    expect(instances).toHaveLength(2);
     expect(instances[0]).toMatchObject({
       location: 'query',
       path: 'foo[1]',
       value: 'baz',
+    });
+    expect(instances[1]).toMatchObject({
+      location: 'query',
+      path: 'foo[2]',
+      value: undefined,
     });
   });
 
@@ -154,7 +161,7 @@ describe('selectFields()', () => {
   });
 
   it('selects inexistent properties', () => {
-    const instances = selectFields({}, ['foo.bar.baz'], ['cookies']);
+    const instances = selectFields({ cookies: { } }, ['foo.bar.baz'], ['cookies']);
 
     expect(instances).toHaveLength(1);
     expect(instances[0]).toEqual({
@@ -165,14 +172,24 @@ describe('selectFields()', () => {
     });
   });
 
-  it('does not select properties of primitives', () => {
+  it('selects properties of primitives', () => {
     const req = {
       body: { foo: 1 },
     };
-    const instances = selectFields(req, ['foo.toFixed'], ['body']);
-    expect(instances).toHaveLength(0);
-  });
+    const instances = selectFields(req, ['foo.toFixed', 'foo.nop'], ['body']);
 
+    expect(instances).toHaveLength(2);
+    expect(instances[0]).toMatchObject({
+      location: 'body',
+      path: 'foo.toFixed',
+      value: expect.any(Function),
+    });
+    expect(instances[1]).toMatchObject({
+      location: 'body',
+      path: 'foo.nop',
+      value: undefined,
+    });
+  });
   it('deduplicates field instances', () => {
     const req = {
       body: {

--- a/src/field-selection.spec.ts
+++ b/src/field-selection.spec.ts
@@ -24,12 +24,14 @@ describe('selectFields()', () => {
       location: 'cookies',
       path: 'foo',
       originalPath: 'foo',
+      pathValues: [],
       value: 'bar',
     });
     expect(instances[1]).toEqual({
       location: 'cookies',
       path: 'baz',
       originalPath: 'baz',
+      pathValues: [],
       value: 'qux',
     });
   });

--- a/src/field-selection.spec.ts
+++ b/src/field-selection.spec.ts
@@ -161,7 +161,7 @@ describe('selectFields()', () => {
   });
 
   it('selects inexistent properties', () => {
-    const instances = selectFields({ cookies: { } }, ['foo.bar.baz'], ['cookies']);
+    const instances = selectFields({ cookies: {} }, ['foo.bar.baz'], ['cookies']);
 
     expect(instances).toHaveLength(1);
     expect(instances[0]).toEqual({

--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -57,11 +57,11 @@ function expandPath(object: any, path: string | string[], currPath: readonly str
         // globstar leaves are always selected
         return [reconstructFieldPath(currPath)];
       }
-      return []
+      return [];
     }
-    if (key === "*") {
+    if (key === '*') {
       // wildcard position does not exist
-      return []
+      return [];
     }
     // value is a primitive, there are still still paths to traverse that will be likely undefined, we return the entire path
     return [reconstructFieldPath([...currPath, ...segments])];

--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -84,7 +84,7 @@ function expandPath(
       // wildcard position does not exist
       return [];
     }
-    // value is a primitive, there are still still paths to traverse that will be likely undefined, we return the entire path
+    // value is a primitive, paths being traversed from here might be in their prototype, return the entire path
     return [
       {
         path: reconstructFieldPath([...currPath, ...segments]),

--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -52,13 +52,19 @@ function expandPath(object: any, path: string | string[], currPath: readonly str
   const rest = segments.slice(1);
 
   if (object != null && !_.isObjectLike(object)) {
-    if (key === '**' && !rest.length) {
-      // globstar leaves are always selected
-      return [reconstructFieldPath(currPath)];
+    if (key === '**') {
+      if (!rest.length) {
+        // globstar leaves are always selected
+        return [reconstructFieldPath(currPath)];
+      }
+      return []
     }
-
-    // there still are paths to traverse, but value is a primitive, stop
-    return [];
+    if (key === "*") {
+      // wildcard position does not exist
+      return []
+    }
+    // value is a primitive, there are still still paths to traverse that will be likely undefined, we return the entire path
+    return [reconstructFieldPath([...currPath, ...segments])];
   }
 
   // Use a non-null value so that inexistent fields are still selected


### PR DESCRIPTION
## Description

Fixes #1245 
It is correct to assume that primitives will not have properties in a request.
Despite that express-validator should provide the correct result, so if a user wants to validate a non existent property we should treat that as undefined.
Eventually in the future we may also update `FieldInstance` to look something like this:

```typescript
export interface FieldInstance {
  path: string;
  originalPath: string;
  location: Location;
  value: any;
  exists: boolean // added property
}
```

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
