### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guides/field-selection.md
+++ b/docs/guides/field-selection.md
@@ -40,7 +40,7 @@ The following table represents what each path would select in the above object:
 | Path                          | Selected value                        |
 | ----------------------------- | ------------------------------------- |
 | `name`                        | `"John McExpress"`                    |
-| `address.work.country`        | `"express-validator land"`            |
+| `addresses.work.country`      | `"express-validator land"`            |
 | `siblings`                    | `[{ "name": "Maria von Validator" }]` |
 | `siblings[0]`                 | `{ "name": "Maria von Validator" }`   |
 | `siblings[0].name`            | `"Maria von Validator"`               |


### PR DESCRIPTION
The spelling mistake is in line 43 where address is used instead of addresses. Found out while reading docs in the website

## Description

Changed spelling of an object in docs/guides/field-selection.md file

This pull request is ready to merge.
