### PR TITLE
docs: add preposition

### DIFF
--- a/docs/guides/field-selection.md
+++ b/docs/guides/field-selection.md
@@ -117,7 +117,7 @@ app.post(
 
 Globstars extend [wildcards](#wildcards) to an infinitely deep level.  
 They can be used when you have an unknown level of nested fields, and want to validate/sanitize all
-them the same way.
+of them the same way.
 
 For example, imagine that your endpoint handles the update of a company's organizational chart.  
 The structure is recursive, so it looks roughly like this:


### PR DESCRIPTION
## Description

There is a missing preposition on line 120 of the `field-selection` page of the docs which I have added. Found this while reading the docs.

This pull request is ready to merge.
