### PR TITLE
Add wildcard values to custom validator's metadata

### DIFF
--- a/docs/api/validation-chain.md
+++ b/docs/api/validation-chain.md
@@ -32,7 +32,7 @@ import { ValidationChain } from 'express-validator';
 ### `.custom()`
 
 ```ts
-custom(validator: (value, { req, location, path }) => any): ValidationChain
+custom(validator: (value, { req, location, path, pathValues }) => any): ValidationChain
 ```
 
 Adds a custom validator function to the chain.
@@ -57,6 +57,29 @@ app.post(
       throw new Error('E-mail already in use');
     }
   }),
+  (req, res) => {
+    // Handle request
+  },
+);
+```
+
+If the field was selected using wildcards or globstars, you can access the values they matched by
+using the `pathValues` property.
+This is useful if you want to use some other property of the same object in your validation:
+
+```ts
+app.post(
+  '/purchase',
+  [
+    body('products.*.quantity').custom((quantity, { req, pathValues }) => {
+      const index = Number(pathValues[0]);
+      const { id } = req.body.products[index];
+
+      if (getProductStock(id) < quantity) {
+        throw new Error(`There's not enough of product ${id} in stock`);
+      }
+    }),
+  ],
   (req, res) => {
     // Handle request
   },
@@ -169,7 +192,7 @@ Please check the documentation on standard validators [here](../guides/validatio
 ### `.customSanitizer()`
 
 ```ts
-customSanitizer(sanitizer: (value, { req, location, path }) => any): ValidationChain
+customSanitizer(sanitizer: (value, { req, location, path, pathValues }) => any): ValidationChain
 ```
 
 Adds a custom sanitizer function to the chain.

--- a/docs/api/validation-chain.md
+++ b/docs/api/validation-chain.md
@@ -63,8 +63,8 @@ app.post(
 );
 ```
 
-If the field was selected using wildcards or globstars, you can access the values they matched by
-using the `pathValues` property.
+If the field was selected using [wildcards or globstars](../guides/field-selection.md#advanced-features),
+you can access the values they matched by using the `pathValues` property.
 This is useful if you want to use some other property of the same object in your validation:
 
 ```ts

--- a/src/base.ts
+++ b/src/base.ts
@@ -34,6 +34,17 @@ export type Meta = {
    * const meta = { req, location: 'body', path: 'foo.bar' }; // req.body.foo.bar
    */
   path: string;
+
+  /**
+   * Values from wildcards/globstars used when selecting fields for validation.
+   *
+   * @example
+   * body('products.*.price').custom((value, { req, pathValues }) => {
+   *  const index = pathValues[0];
+   *  const productName = req.body.products[index].name;
+   * });
+   */
+  pathValues: readonly (string | string[])[];
 };
 
 /**
@@ -53,6 +64,7 @@ export type StandardSanitizer = (input: string, ...options: any[]) => any;
 export interface FieldInstance {
   path: string;
   originalPath: string;
+  pathValues: readonly (string | string[])[];
   location: Location;
   value: any;
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -69,7 +69,10 @@ export interface FieldInstance {
   value: any;
 }
 
-export type UnknownFieldInstance = Omit<FieldInstance, 'originalPath'>;
+// pathValues is omitted as it doesn't make sense when a globstar is involved:
+// With known fields `**.foo` and request `{ obj: { foo: 1, bar: 2 } }`,
+// the globstar matches the whole field path every time.
+export type UnknownFieldInstance = Omit<FieldInstance, 'originalPath' | 'pathValues'>;
 
 export type FieldValidationError = {
   /**

--- a/src/chain/context-runner-impl.spec.ts
+++ b/src/chain/context-runner-impl.spec.ts
@@ -12,8 +12,8 @@ let selectFields: jest.Mock;
 let contextRunner: ContextRunnerImpl;
 
 const instances: FieldInstance[] = [
-  { location: 'query', path: 'foo', originalPath: 'foo', value: 123 },
-  { location: 'query', path: 'bar', originalPath: 'bar', value: 456 },
+  { location: 'query', path: 'foo', originalPath: 'foo', pathValues: [], value: 123 },
+  { location: 'query', path: 'bar', originalPath: 'bar', pathValues: ['1'], value: 456 },
 ];
 
 // Used in value persistence tests
@@ -72,6 +72,7 @@ it('runs items on the stack with required data', async () => {
         req,
         location: instance.location,
         path: instance.path,
+        pathValues: instance.pathValues,
       });
     });
   });
@@ -118,7 +119,11 @@ it('does not run items if a previous context halts the whole request', async () 
   const context2 = new ContextBuilder().addItem({ run: jest.fn() }).build();
 
   const req = {};
-  context1.addError({ type: 'field', value: 1, meta: { req, location: 'params', path: 'foo' } });
+  context1.addError({
+    type: 'field',
+    value: 1,
+    meta: { req, location: 'params', path: 'foo', pathValues: [] },
+  });
 
   await new ContextRunnerImpl(context1, selectFields).run(req);
   await new ContextRunnerImpl(context2, selectFields).run(req);
@@ -145,6 +150,7 @@ it('stops running items on paths that got a validation halt', async () => {
     req,
     location: instances[1].location,
     path: instances[1].path,
+    pathValues: instances[1].pathValues,
   });
 });
 

--- a/src/chain/context-runner-impl.ts
+++ b/src/chain/context-runner-impl.ts
@@ -50,6 +50,7 @@ export class ContextRunnerImpl implements ContextRunner {
             req,
             location,
             path,
+            pathValues: instance.pathValues,
           });
 
           // An instance is mutable, so if an item changed its value, there's no need to call getData again

--- a/src/chain/sanitizers-impl.spec.ts
+++ b/src/chain/sanitizers-impl.spec.ts
@@ -116,12 +116,13 @@ describe('#toArray()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const toArray = context.stack[0];
 
     await toArray.run(context, [], meta);
@@ -158,12 +159,13 @@ describe('#toLowerCase()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const toLowerCase = context.stack[0];
 
     await toLowerCase.run(context, '', meta);
@@ -201,12 +203,13 @@ describe('#toUpperCase()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const toUpperCase = context.stack[0];
 
     await toUpperCase.run(context, '', meta);
@@ -244,12 +247,13 @@ describe('#default()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const defaultSanitizer = context.stack[0];
 
     await defaultSanitizer.run(context, 'foo', meta);
@@ -287,12 +291,13 @@ describe('#replace()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const replace = context.stack[0];
 
     await replace.run(context, '', meta);
@@ -321,12 +326,13 @@ describe('#replace()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const replace = context.stack[0];
 
     await replace.run(context, 'foo', meta);
@@ -358,12 +364,13 @@ describe('#replace()', () => {
       {
         location: 'body',
         path: 'foo',
+        pathValues: [],
         originalPath: 'foo',
         value: '',
       },
     ]);
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const replace = context.stack[0];
 
     await replace.run(context, 'foo', meta);

--- a/src/chain/validators-impl.spec.ts
+++ b/src/chain/validators-impl.spec.ts
@@ -75,7 +75,7 @@ describe('#exists()', () => {
     validators.exists();
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const exists = context.stack[0];
 
     await exists.run(context, undefined, meta);
@@ -91,7 +91,7 @@ describe('#exists()', () => {
     validators.exists({ checkFalsy: true });
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const exists = context.stack[0];
 
     await exists.run(context, undefined, meta);
@@ -108,7 +108,7 @@ describe('#exists()', () => {
     validators.exists({ checkNull: true });
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const exists = context.stack[0];
 
     await exists.run(context, undefined, meta);
@@ -148,7 +148,7 @@ describe('default #isBoolean()', () => {
     validators.isBoolean();
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isBoolean = context.stack[0];
 
     await isBoolean.run(context, true, meta);
@@ -182,7 +182,7 @@ describe('strict #isBoolean()', () => {
     validators.isBoolean({ strict: true });
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isBoolean = context.stack[0];
 
     await isBoolean.run(context, true, meta);
@@ -213,7 +213,7 @@ describe('loose #isBoolean()', () => {
     validators.isBoolean({ loose: true });
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isBoolean = context.stack[0];
 
     await isBoolean.run(context, true, meta);
@@ -246,7 +246,7 @@ describe('#isString()', () => {
     validators.isString();
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isString = context.stack[0];
 
     await isString.run(context, 'foo', meta);
@@ -273,7 +273,7 @@ describe('#isObject()', () => {
     validators.isObject();
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isObject = context.stack[0];
 
     await isObject.run(context, {}, meta);
@@ -293,7 +293,7 @@ describe('#isObject()', () => {
     validators.isObject({});
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isObject = context.stack[0];
 
     await isObject.run(context, {}, meta);
@@ -313,7 +313,7 @@ describe('#isObject()', () => {
     validators.isObject({ strict: false });
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isObject = context.stack[0];
 
     await isObject.run(context, {}, meta);
@@ -342,7 +342,7 @@ describe('#isArray()', () => {
     validators.isArray();
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isArray = context.stack[0];
 
     await isArray.run(context, [], meta);
@@ -360,7 +360,7 @@ describe('#isArray()', () => {
     validators.isArray({ min: 2, max: 5 });
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const isArray = context.stack[0];
 
     await isArray.run(context, [1, '2'], meta);
@@ -400,7 +400,7 @@ describe('#isULID()', () => {
     validators.isULID();
     const context = builder.build();
 
-    const meta: Meta = { req: {}, location: 'body', path: 'foo' };
+    const meta: Meta = { req: {}, location: 'body', path: 'foo', pathValues: [] };
     const exists = context.stack[0];
 
     const valid = [

--- a/src/context-items/bail.spec.ts
+++ b/src/context-items/bail.spec.ts
@@ -17,6 +17,7 @@ it('throws a validation halt if the context has errors', () => {
       req: {},
       location: 'body',
       path: 'bar',
+      pathValues: [],
     },
   });
 

--- a/src/context-items/chain-condition.spec.ts
+++ b/src/context-items/chain-condition.spec.ts
@@ -17,6 +17,7 @@ beforeEach(() => {
       req,
       location: 'params',
       path: 'id',
+      pathValues: [],
     });
 });
 

--- a/src/context-items/custom-condition.spec.ts
+++ b/src/context-items/custom-condition.spec.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
       req: {},
       location: 'cookies',
       path: 'foo',
+      pathValues: [],
     });
 });
 
@@ -25,6 +26,7 @@ it('runs the condition with the value and the meta', () => {
     req: {},
     location: 'cookies',
     path: 'foo',
+    pathValues: [],
   });
 });
 

--- a/src/context-items/custom-validation.spec.ts
+++ b/src/context-items/custom-validation.spec.ts
@@ -10,6 +10,7 @@ const meta: Meta = {
   req: { cookies: { foo: 'bar' } },
   location: 'cookies',
   path: 'foo',
+  pathValues: [],
 };
 
 beforeEach(() => {

--- a/src/context-items/sanitization.spec.ts
+++ b/src/context-items/sanitization.spec.ts
@@ -11,6 +11,7 @@ const meta: Meta = {
   req: { cookies: { foo: 'bar' } },
   location: 'cookies',
   path: 'foo',
+  pathValues: [],
 };
 
 beforeEach(() => {
@@ -19,6 +20,7 @@ beforeEach(() => {
     {
       location: 'cookies',
       path: 'foo',
+      pathValues: [],
       originalPath: 'foo',
       value: 123,
     },

--- a/src/context-items/standard-validation.spec.ts
+++ b/src/context-items/standard-validation.spec.ts
@@ -11,6 +11,7 @@ const meta: Meta = {
   req: { cookies: { foo: 'bar' } },
   location: 'cookies',
   path: 'foo',
+  pathValues: [],
 };
 
 beforeEach(() => {

--- a/src/context.spec.ts
+++ b/src/context.spec.ts
@@ -12,12 +12,14 @@ beforeEach(() => {
       location: 'body',
       originalPath: 'foo',
       path: 'foo',
+      pathValues: [],
       value: 123,
     },
     {
       location: 'params',
       originalPath: 'bar.baz',
       path: 'bar.baz',
+      pathValues: [],
       value: false,
     },
   ];
@@ -26,6 +28,7 @@ beforeEach(() => {
 describe('#addError()', () => {
   const meta: Meta = {
     path: 'bar',
+    pathValues: [],
     location: 'headers',
     req: {},
   };

--- a/src/express-validator.spec.ts
+++ b/src/express-validator.spec.ts
@@ -44,7 +44,7 @@ describe('ExpressValidator', () => {
 
       await chain.run(req);
       locations.forEach(location => {
-        const meta: Meta = { req, location, path: 'foo' };
+        const meta: Meta = { req, location, path: 'foo', pathValues: [] };
         expect(isAllowedDomain).toHaveBeenCalledWith(foo, meta);
         expect(removeEmailAttribute).toHaveBeenCalledWith(foo, meta);
       });

--- a/src/field-selection.spec.ts
+++ b/src/field-selection.spec.ts
@@ -10,6 +10,7 @@ describe('selectFields()', () => {
       location: 'cookies',
       path: 'foo',
       originalPath: 'foo',
+      pathValues: [],
       value: 'bar',
     });
   });
@@ -161,6 +162,7 @@ describe('selectFields()', () => {
       location: 'cookies',
       path: 'foo.bar.baz',
       originalPath: 'foo.bar.baz',
+      pathValues: [],
       value: undefined,
     });
   });
@@ -207,12 +209,14 @@ describe('selectFields()', () => {
         location: 'query',
         path: 'foo[0]',
         originalPath: 'foo.*',
+        pathValues: ['0'],
         value: 'bar',
       });
       expect(instances[1]).toMatchObject({
         location: 'query',
         path: 'foo[1]',
         originalPath: 'foo.*',
+        pathValues: ['1'],
         value: 'baz',
       });
     });
@@ -228,12 +232,14 @@ describe('selectFields()', () => {
         location: 'body',
         path: '[0]',
         originalPath: '*',
+        pathValues: ['0'],
         value: 'bar',
       });
       expect(instances[1]).toMatchObject({
         location: 'body',
         path: '[1]',
         originalPath: '*',
+        pathValues: ['1'],
         value: 'baz',
       });
     });
@@ -249,6 +255,7 @@ describe('selectFields()', () => {
         location: 'query',
         path: '*',
         originalPath: '*',
+        pathValues: ['*'],
         value: 'foo',
       });
     });
@@ -264,13 +271,38 @@ describe('selectFields()', () => {
         location: 'query',
         path: 'foo.bar.a',
         originalPath: 'foo.*.a',
+        pathValues: ['bar'],
         value: true,
       });
       expect(instances[1]).toMatchObject({
         location: 'query',
         path: 'foo.baz.a',
         originalPath: 'foo.*.a',
+        pathValues: ['baz'],
         value: false,
+      });
+    });
+
+    it('selects fields matching multiple wildcards', () => {
+      const req = {
+        query: { foo: { bar: { a: true }, baz: { b: 1 } } },
+      };
+      const instances = selectFields(req, ['foo.*.*'], ['query']);
+
+      expect(instances).toHaveLength(2);
+      expect(instances[0]).toMatchObject({
+        location: 'query',
+        path: 'foo.bar.a',
+        originalPath: 'foo.*.*',
+        pathValues: ['bar', 'a'],
+        value: true,
+      });
+      expect(instances[1]).toMatchObject({
+        location: 'query',
+        path: 'foo.baz.b',
+        originalPath: 'foo.*.*',
+        pathValues: ['baz', 'b'],
+        value: 1,
       });
     });
 
@@ -296,12 +328,14 @@ describe('selectFields()', () => {
         location: 'query',
         path: 'foo.a.b.c',
         originalPath: 'foo.**',
+        pathValues: [['a', 'b', 'c']],
         value: 1,
       });
       expect(instances[1]).toMatchObject({
         location: 'query',
         path: 'foo.d.e',
         originalPath: 'foo.**',
+        pathValues: [['d', 'e']],
         value: 2,
       });
     });
@@ -317,12 +351,14 @@ describe('selectFields()', () => {
         location: 'query',
         path: 'foo.a.b.bar',
         originalPath: 'foo.**.bar',
+        pathValues: [['a', 'b']],
         value: 1,
       });
       expect(instances[1]).toMatchObject({
         location: 'query',
         path: 'foo.c.bar',
         originalPath: 'foo.**.bar',
+        pathValues: [['c']],
         value: 2,
       });
     });
@@ -338,12 +374,14 @@ describe('selectFields()', () => {
         location: 'query',
         path: 'foo.foo',
         originalPath: '**.foo',
+        pathValues: [['foo']],
         value: 1,
       });
       expect(instances[1]).toMatchObject({
         location: 'query',
         path: 'foo',
         originalPath: '**.foo',
+        pathValues: [],
         value: { foo: 1 },
       });
     });
@@ -359,6 +397,7 @@ describe('selectFields()', () => {
         location: 'query',
         path: '**',
         originalPath: '**',
+        pathValues: [['**']],
         value: 'foo',
       });
     });

--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -30,22 +30,38 @@ function expandField(req: Request, field: string, location: Location): FieldInst
 
   const paths = expandPath(req[location], pathToExpand, []);
 
-  return paths.map(path => {
+  return paths.map(({ path, values }) => {
     const value = path === '' ? req[location] : _.get(req[location], path);
     return {
       location,
       path,
       originalPath,
+      pathValues: values,
       value,
     };
   });
 }
 
-function expandPath(object: any, path: string | string[], currPath: readonly string[]): string[] {
+type PathWithValues = {
+  path: string;
+  values: readonly (string | string[])[];
+};
+
+function expandPath(
+  object: any,
+  path: string | string[],
+  currPath: readonly string[],
+  currValues: readonly any[] = [],
+): PathWithValues[] {
   const segments = _.toPath(path);
   if (!segments.length) {
     // no more paths to traverse
-    return [reconstructFieldPath(currPath)];
+    return [
+      {
+        path: reconstructFieldPath(currPath),
+        values: currValues,
+      },
+    ];
   }
 
   const key = segments[0];
@@ -54,7 +70,12 @@ function expandPath(object: any, path: string | string[], currPath: readonly str
   if (object != null && !_.isObjectLike(object)) {
     if (key === '**' && !rest.length) {
       // globstar leaves are always selected
-      return [reconstructFieldPath(currPath)];
+      return [
+        {
+          path: reconstructFieldPath(currPath),
+          values: currValues,
+        },
+      ];
     }
 
     // there still are paths to traverse, but value is a primitive, stop
@@ -64,23 +85,27 @@ function expandPath(object: any, path: string | string[], currPath: readonly str
   // Use a non-null value so that inexistent fields are still selected
   object = object || {};
   if (key === '*') {
-    return Object.keys(object).flatMap(key => expandPath(object[key], rest, currPath.concat(key)));
+    return Object.keys(object).flatMap(key =>
+      expandPath(object[key], rest, currPath.concat(key), currValues.concat(key)),
+    );
   }
   if (key === '**') {
     return Object.keys(object).flatMap(key => {
       const nextPath = currPath.concat(key);
       const value = object[key];
-      const set = new Set([
-        // recursively find matching subpaths
-        ...expandPath(value, segments, nextPath),
+      // recursively find matching subpaths
+      const selectedPaths = expandPath(value, segments, nextPath, [key]).concat(
         // skip the first remaining segment, if it matches the current key
-        ...(rest[0] === key ? expandPath(value, rest.slice(1), nextPath) : []),
-      ]);
-      return [...set];
+        rest[0] === key ? expandPath(value, rest.slice(1), nextPath, []) : [],
+      );
+      return _.uniqBy(selectedPaths, ({ path }) => path).map(({ path, values }) => ({
+        path,
+        values: values.length ? [...currValues, values.flat()] : currValues,
+      }));
     });
   }
 
-  return expandPath(object[key], rest, currPath.concat(key));
+  return expandPath(object[key], rest, currPath.concat(key), currValues);
 }
 
 type Tree = { [K: string]: Tree | undefined };


### PR DESCRIPTION
## Description

Adds `pathValues` to the `Meta` interface, used by `custom()` and `customSanitizer()`.
It's an array of values that come from wildcards or globstars.

Closes #1297 

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [x] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
