### PR TITLE
refactor: use "forEach" instead of "map"

### DIFF
--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -126,7 +126,7 @@ export const selectUnknownFields = (
   locations: Location[],
 ): UnknownFieldInstance[] => {
   const tree: Tree = {};
-  knownFields.map(field => {
+  knownFields.forEach(field => {
     const segments = field === '' ? [''] : _.toPath(field);
     pathToTree(segments, tree);
   });


### PR DESCRIPTION
## Description

use forEach instead of map because the return value is not used

## To-do list

<!-- Put an "x" to indicate you've done each of the following -->

- [ ] I have added tests for what I changed.

<!-- If this pull request isn't ready, add any remaining tasks here -->

- [x] This pull request is ready to merge.
