### PR TITLE
fix: escape reconstructed field path segments

### DIFF
--- a/src/field-selection.spec.ts
+++ b/src/field-selection.spec.ts
@@ -567,6 +567,9 @@ describe('reconstructFieldPath()', () => {
     ['numeric segment between text segments', ['foo', '0', 'bar'], 'foo[0].bar'],
     ['numeric segment followed by numeric segment', ['foo', '0', '0'], 'foo[0][0]'],
     ['text segment with a dot', ['foo', '.bar'], 'foo[".bar"]'],
+    ['text segment with brackets', ['foo', '["bar"]'], 'foo["[\\"bar\\"]"]'],
+    ['text segment with quotes', ['foo', 'bar"baz'], 'foo["bar\\"baz"]'],
+    ['text segment with backslashes', ['foo', 'bar\\baz'], 'foo["bar\\\\baz"]'],
   ])('%s', (_name, input, expected) => {
     expect(reconstructFieldPath(input)).toBe(expected);
   });

--- a/src/field-selection.ts
+++ b/src/field-selection.ts
@@ -252,10 +252,9 @@ export function reconstructFieldPath(segments: readonly string[]): string {
     let part = '';
     segment = segment === '\\*' ? '*' : segment;
 
-    // TODO: Handle brackets?
-    if (segment.includes('.')) {
+    if (/[.[\]"\\]/.test(segment)) {
       // Special char key access
-      part = `["${segment}"]`;
+      part = `[${JSON.stringify(segment)}]`;
     } else if (/^\d+$/.test(segment)) {
       // Index access
       part = `[${segment}]`;

--- a/src/matched-data.spec.ts
+++ b/src/matched-data.spec.ts
@@ -38,6 +38,26 @@ it('includes data that was validated with wildcards', done => {
   });
 });
 
+it('keeps wildcard-expanded bracket-notation keys from overwriting validated fields', done => {
+  const req = {
+    body: {
+      role: 'user',
+      '["role"]': 'admin',
+    },
+  };
+
+  check('role').isIn(['user', 'moderator'])(req, {}, () => {
+    check('*').isString()(req, {}, () => {
+      expect(matchedData(req)).toEqual({
+        role: 'user',
+        '["role"]': 'admin',
+      });
+
+      done();
+    });
+  });
+});
+
 it('does not include valid data from invalid oneOf() chain group', done => {
   const req = {
     query: { foo: 'foo', bar: 123, baz: 'baz' },


### PR DESCRIPTION
Fixes #1368.

This updates `reconstructFieldPath()` so segments containing brackets, quotes, or backslashes are emitted as quoted bracket segments using `JSON.stringify()`. That keeps wildcard-expanded field names such as `["role"]` as literal keys when `matchedData()` later writes them with lodash `_.set()`.

The change preserves the existing behavior for normal object paths, numeric array indexes, and wildcard literals.

I also added regression coverage for:

- reconstructed paths containing brackets, quotes, and backslashes
- `matchedData()` keeping a wildcard-expanded `["role"]` key from overwriting a separately validated `role` field

Checks run:

- `npx jest src/field-selection.spec.ts src/matched-data.spec.ts --runInBand`
- `npm test -- --runInBand`
- `npm run build`
- `npm run lint`